### PR TITLE
fix(ios): Keychain → UserDefaults migration + mDNS port bind

### DIFF
--- a/apps/ios/Kelpie/Device/DeviceIdentity.swift
+++ b/apps/ios/Kelpie/Device/DeviceIdentity.swift
@@ -1,39 +1,48 @@
 import Foundation
-import UIKit
 import Security
+import UIKit
 
-/// Provides a stable device UUID that persists across app installs.
+/// Provides a stable device UUID that persists across app launches.
+/// Stored in `UserDefaults`. Older builds wrote the value to Keychain;
+/// the first read after upgrade migrates it out of Keychain and removes
+/// the legacy entry so subsequent reads never touch Security.framework.
 enum DeviceIdentity {
-    private static let keychainKey = "com.kelpie.device-id"
+    private static let defaultsKey = "com.kelpie.device-id"
 
     static var id: String {
-        if let stored = readFromKeychain() { return stored }
+        if let stored = UserDefaults.standard.string(forKey: defaultsKey), !stored.isEmpty {
+            return stored
+        }
+        if let migrated = migrateFromKeychain() {
+            UserDefaults.standard.set(migrated, forKey: defaultsKey)
+            return migrated
+        }
         let newId = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
-        saveToKeychain(newId)
+        UserDefaults.standard.set(newId, forKey: defaultsKey)
         return newId
     }
 
-    private static func readFromKeychain() -> String? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: keychainKey,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne
+    /// One-time backward-compat read of the legacy Keychain entry.
+    /// Returns the stored value (if any) and removes the Keychain entry
+    /// so the app never reads from Keychain again.
+    private static func migrateFromKeychain() -> String? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: defaultsKey,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
         ]
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess, let data = result as? Data else { return nil }
-        return String(data: data, encoding: .utf8)
-    }
-
-    private static func saveToKeychain(_ value: String) {
-        let data = Data(value.utf8)
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: keychainKey,
-            kSecValueData as String: data
+        guard status == errSecSuccess, let data = result as? Data,
+              let value = String(data: data, encoding: .utf8), !value.isEmpty else {
+            return nil
+        }
+        let deleteQuery: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: defaultsKey
         ]
-        SecItemDelete(query as CFDictionary)
-        SecItemAdd(query as CFDictionary, nil)
+        SecItemDelete(deleteQuery as CFDictionary)
+        return value
     }
 }

--- a/apps/ios/Kelpie/Network/HTTPServer.swift
+++ b/apps/ios/Kelpie/Network/HTTPServer.swift
@@ -3,10 +3,18 @@ import Network
 
 /// Embedded HTTP server for receiving CLI commands.
 /// Uses raw NWListener since we want zero external dependencies for the server.
+///
+/// The same `NWListener` also carries the Bonjour/mDNS advertisement when one
+/// is attached via `attachService(_:)`. This keeps the published port and the
+/// listening port in lockstep — Network.framework publishes whatever port the
+/// listener is bound to, so advertising via a second standalone listener would
+/// announce an ephemeral port that no one is serving on.
 final class HTTPServer: @unchecked Sendable {
     let port: UInt16
     let router: Router
     private var listener: NWListener?
+    private var pendingService: NWListener.Service?
+    var serviceRegistrationUpdateHandler: ((NWListener.ServiceRegistrationChange) -> Void)?
 
     init(port: UInt16 = 8420, router: Router) {
         self.port = port
@@ -24,10 +32,15 @@ final class HTTPServer: @unchecked Sendable {
             return
         }
 
+        if let service = pendingService {
+            listener?.service = service
+        }
+
         listener?.newConnectionHandler = { [weak self] connection in
             self?.handleConnection(connection)
         }
-        listener?.stateUpdateHandler = { state in
+        listener?.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
             switch state {
             case .ready:
                 print("[HTTPServer] Listening on port \(self.port)")
@@ -37,12 +50,23 @@ final class HTTPServer: @unchecked Sendable {
                 break
             }
         }
+        listener?.serviceRegistrationUpdateHandler = { [weak self] change in
+            self?.serviceRegistrationUpdateHandler?(change)
+        }
         listener?.start(queue: .global(qos: .userInitiated))
     }
 
     func stop() {
         listener?.cancel()
         listener = nil
+    }
+
+    /// Attach a Bonjour service to the listener. If the listener is already
+    /// running the service starts publishing immediately; otherwise it is held
+    /// until `start()` is called. Passing `nil` clears the service.
+    func attachService(_ service: NWListener.Service?) {
+        pendingService = service
+        listener?.service = service
     }
 
     private func handleConnection(_ connection: NWConnection) {

--- a/apps/ios/Kelpie/Network/MDNSAdvertiser.swift
+++ b/apps/ios/Kelpie/Network/MDNSAdvertiser.swift
@@ -1,77 +1,62 @@
 import Foundation
 import Network
 
-/// Advertises the Kelpie service via mDNS using Network.framework.
+/// Publishes the Kelpie Bonjour service on the live `HTTPServer` listener.
+///
+/// We deliberately avoid creating a second `NWListener` here: a standalone
+/// listener would bind an ephemeral port, and Network.framework advertises
+/// whatever port the listener actually owns — not the value stuffed into the
+/// TXT record. Attaching the `NWListener.Service` to `HTTPServer`'s listener
+/// guarantees the advertised port matches the port the API server is serving
+/// on.
 final class MDNSAdvertiser: @unchecked Sendable {
-    private var listener: NWListener?
     private let serviceType = "_kelpie._tcp"
+    private weak var httpServer: HTTPServer?
     let txtRecord: [String: String]
     var onAdvertisingChange: ((Bool) -> Void)?
     private(set) var isRunning = false
 
-    init(txtRecord: [String: String]) {
+    init(txtRecord: [String: String], httpServer: HTTPServer) {
         self.txtRecord = txtRecord
+        self.httpServer = httpServer
     }
 
     func start() {
-        stop()
-
-        do {
-            listener = try NWListener(using: .tcp)
-        } catch {
-            print("[mDNS] Failed to create listener: \(error)")
+        guard let httpServer else {
+            print("[mDNS] No HTTPServer to attach service to")
             onAdvertisingChange?(false)
             return
         }
 
-        let txt = NWTXTRecord(txtRecord)
-        listener?.service = NWListener.Service(
-            name: txtRecord["name"] ?? "Kelpie",
-            type: serviceType,
-            txtRecord: txt
-        )
-
-        listener?.serviceRegistrationUpdateHandler = { change in
+        httpServer.serviceRegistrationUpdateHandler = { [weak self] change in
+            guard let self else { return }
             switch change {
             case .add(let endpoint):
+                self.isRunning = true
+                self.onAdvertisingChange?(true)
                 print("[mDNS] Advertising: \(endpoint)")
             case .remove(let endpoint):
+                self.isRunning = false
+                self.onAdvertisingChange?(false)
                 print("[mDNS] Removed: \(endpoint)")
             @unknown default:
                 break
             }
         }
 
-        listener?.stateUpdateHandler = { state in
-            switch state {
-            case .ready:
-                self.isRunning = true
-                self.onAdvertisingChange?(true)
-                print("[mDNS] Service advertised as \(self.serviceType)")
-            case .failed(let error):
-                self.isRunning = false
-                self.onAdvertisingChange?(false)
-                print("[mDNS] Advertisement failed: \(error)")
-            case .cancelled:
-                self.isRunning = false
-                self.onAdvertisingChange?(false)
-            default:
-                break
-            }
-        }
-
-        // We don't actually need to accept connections on this listener.
-        // It exists solely for mDNS advertisement.
-        listener?.newConnectionHandler = { connection in
-            connection.cancel()
-        }
-
-        listener?.start(queue: .global(qos: .utility))
+        let txt = NWTXTRecord(txtRecord)
+        let service = NWListener.Service(
+            name: txtRecord["name"] ?? "Kelpie",
+            type: serviceType,
+            txtRecord: txt
+        )
+        httpServer.attachService(service)
+        print("[mDNS] Service requested as \(serviceType) on port \(httpServer.port)")
     }
 
     func stop() {
-        listener?.cancel()
-        listener = nil
+        httpServer?.attachService(nil)
+        httpServer?.serviceRegistrationUpdateHandler = nil
         isRunning = false
         onAdvertisingChange?(false)
     }

--- a/apps/ios/Kelpie/Network/ServerState.swift
+++ b/apps/ios/Kelpie/Network/ServerState.swift
@@ -203,7 +203,12 @@ final class ServerState: ObservableObject {
             return
         }
 
-        let advertiser = MDNSAdvertiser(txtRecord: deviceInfo.txtRecord)
+        guard let httpServer else {
+            print("[mDNS] HTTPServer not started; cannot publish service")
+            return
+        }
+
+        let advertiser = MDNSAdvertiser(txtRecord: deviceInfo.txtRecord, httpServer: httpServer)
         advertiser.onAdvertisingChange = { [weak self] isAdvertising in
             DispatchQueue.main.async {
                 self?.isMDNSAdvertising = isAdvertising


### PR DESCRIPTION
## Summary

Fixes two confirmed iOS bugs.

### Bug 1 — Keychain violation (AGENTS.md "No Keychain")
`DeviceIdentity` used `SecItemAdd` / `SecItemCopyMatching` / `SecItemDelete` to persist the device UUID. The project rule forbids any Keychain use.

**Fix:** Storage now lives in `UserDefaults.standard` under `"com.kelpie.device-id"` (same scheme as the macOS app). On the first read after upgrade, the code performs a one-time read of the legacy Keychain entry, writes the value into `UserDefaults`, and deletes the Keychain row. Subsequent reads never touch Security.framework. The `Security` import is still required to compile the one-time migration call; it is unused at runtime after the first launch.

Migration semantics:
- Existing installs keep their existing device id (read from Keychain once, persisted to UserDefaults, deleted from Keychain).
- Fresh installs get `UIDevice.identifierForVendor` (or a random UUID fallback).
- After migration, the keychain entry no longer exists and the code path that touches Keychain is never re-entered for that device id.

### Bug 2 — mDNS port mismatch
`MDNSAdvertiser` created an `NWListener(using: .tcp)` with no `on: port`, so it bound an ephemeral port. The TXT record advertised `port=8420` but Bonjour publishes whatever port the listener actually owns. The listener also immediately cancelled every inbound connection.

**Fix:** Removed the standalone `NWListener` entirely. `HTTPServer` gained `attachService(_:)` and a public `serviceRegistrationUpdateHandler` callback; the Bonjour service is now attached to the HTTP server's own `NWListener`. This guarantees the published port matches the port the API is serving on, with no duplicate listener.

Also:
- `MDNSAdvertiser.init` now takes the `HTTPServer` instance; `ServerState.startMDNS()` updated to pass it through and to bail safely if MDNS is started before HTTP.
- `HTTPServer` state-update closure switched to `[weak self]` to remove the implicit `self` capture noted in review.
- `MDNSAdvertiser` callbacks all use `[weak self]`.

## Verification

- `make lint-swift` — passes (0 violations, 161 files).
- `xcodebuild -workspace apps/ios/Kelpie.xcworkspace -scheme Kelpie -destination 'generic/platform=iOS Simulator,name=iPhone 15' build` — **BUILD SUCCEEDED**, no warnings or errors on the modified files.

## Test plan

- [ ] Install on a device that previously stored a device id in Keychain; verify the same id is reported via `/v1/get-device-info` and the Keychain entry is removed.
- [ ] Fresh install on a clean device; verify a stable id is generated and persists across relaunches.
- [ ] From another machine on the LAN, `dns-sd -B _kelpie._tcp local.` then `dns-sd -L "<name>" _kelpie._tcp` — confirm the advertised port is 8420 (or the configured port) and the API responds on it.