### PR TITLE
fix(macos): HTTPServer hardening + silent-swallow audit

### DIFF
--- a/apps/macos/Kelpie/Handlers/HandlerContext.swift
+++ b/apps/macos/Kelpie/Handlers/HandlerContext.swift
@@ -415,6 +415,7 @@ extension Notification.Name {
 
 enum HandlerError: Error {
     case noWebView
+    case rendererHidden
     case elementNotFound(String)
     case screenshotFailed
     case timeout
@@ -432,6 +433,13 @@ func tabErrorResponse(from error: Error) -> [String: Any]? {
         return errorResponse(
             code: "TAB_REQUIRED",
             message: "Multiple tabs open — specify \"tabId\" in your request. Available tabs:\n\(listing)"
+        )
+    case .rendererHidden:
+        return errorResponse(
+            code: "RENDERER_HIDDEN",
+            message: "The active renderer is hidden — its view is detached or off-screen, " +
+                "so script evaluation and DOM queries are unavailable. Bring the window " +
+                "to front or switch to a renderer whose view is visible."
         )
     default:
         return nil

--- a/apps/macos/Kelpie/Handlers/InteractionHandler.swift
+++ b/apps/macos/Kelpie/Handlers/InteractionHandler.swift
@@ -204,33 +204,41 @@ struct InteractionHandler {
             await context.showTouchIndicatorForElement(selector, color: color, tabId: tabId)
         }
         let delay = body["delay"] as? Int ?? 50
-        for char in text {
-            if context.scriptPlaybackState?.isAbortRequested() == true { break }
-            let escapedChar = JSEscape.string(String(char))
-            let charJS = """
+        do {
+            for char in text {
+                if context.scriptPlaybackState?.isAbortRequested() == true { break }
+                let escapedChar = JSEscape.string(String(char))
+                let charJS = """
+                (function() {
+                    \(formControlMutationScript())
+                    var el = document.activeElement;
+                    if (!el) return;
+                    el.dispatchEvent(new KeyboardEvent('keydown', {key: '\(escapedChar)', bubbles: true}));
+                    el.dispatchEvent(new KeyboardEvent('keypress', {key: '\(escapedChar)', bubbles: true}));
+                    kelpieWriteFormControlValue(el, kelpieReadFormControlValue(el) + '\(escapedChar)');
+                    kelpieDispatchFormControlInput(el);
+                    el.dispatchEvent(new KeyboardEvent('keyup', {key: '\(escapedChar)', bubbles: true}));
+                })()
+                """
+                _ = try await context.evaluateJS(charJS, tabId: tabId)
+                try? await Task.sleep(nanoseconds: UInt64(delay) * 1_000_000)
+            }
+            let finalizeJS = """
             (function() {
                 \(formControlMutationScript())
                 var el = document.activeElement;
                 if (!el) return;
-                el.dispatchEvent(new KeyboardEvent('keydown', {key: '\(escapedChar)', bubbles: true}));
-                el.dispatchEvent(new KeyboardEvent('keypress', {key: '\(escapedChar)', bubbles: true}));
-                kelpieWriteFormControlValue(el, kelpieReadFormControlValue(el) + '\(escapedChar)');
-                kelpieDispatchFormControlInput(el);
-                el.dispatchEvent(new KeyboardEvent('keyup', {key: '\(escapedChar)', bubbles: true}));
+                kelpieDispatchFormControlChange(el);
             })()
             """
-            _ = try? await context.evaluateJS(charJS, tabId: tabId)
-            try? await Task.sleep(nanoseconds: UInt64(delay) * 1_000_000)
+            _ = try await context.evaluateJS(finalizeJS, tabId: tabId)
+        } catch {
+            if let tabError = tabErrorResponse(from: error) { return tabError }
+            return errorResponse(
+                code: "TYPING_FAILED",
+                message: "Failed to dispatch keystrokes: \(error.localizedDescription)"
+            )
         }
-        let finalizeJS = """
-        (function() {
-            \(formControlMutationScript())
-            var el = document.activeElement;
-            if (!el) return;
-            kelpieDispatchFormControlChange(el);
-        })()
-        """
-        _ = try? await context.evaluateJS(finalizeJS, tabId: tabId)
         return successResponse(["typed": text])
     }
 

--- a/apps/macos/Kelpie/KelpieApp.swift
+++ b/apps/macos/Kelpie/KelpieApp.swift
@@ -281,8 +281,7 @@ struct KelpieApp: App {
     }
 
     private func startServices() {
-        serverState.rendererState = rendererState
-        serverState.startHTTPServer()
+        serverState.startHTTPServer(rendererState: rendererState)
         #if DEBUG
         if Self.canBind(port: 8421) {
             AppReveal.start(port: 8421)

--- a/apps/macos/Kelpie/Network/HTTPServer.swift
+++ b/apps/macos/Kelpie/Network/HTTPServer.swift
@@ -1,9 +1,31 @@
 import Foundation
 import Network
 
+/// Errors thrown by HTTPServer for unrecoverable startup conditions.
+enum HTTPServerError: Error, CustomStringConvertible {
+    case invalidPort(UInt16)
+
+    var description: String {
+        switch self {
+        case .invalidPort(let port):
+            return "Invalid HTTP server port: \(port)"
+        }
+    }
+}
+
 /// Embedded HTTP server for receiving CLI commands.
 /// Uses raw NWListener since we want zero external dependencies for the server.
 final class HTTPServer: @unchecked Sendable {
+    /// Maximum bytes accepted for HTTP request headers before parsing must complete.
+    /// 16 KiB matches Nginx/Apache defaults and keeps slow-loris pinning bounded.
+    static let maxHeaderBytes = 16 * 1024
+    /// Maximum request body size accepted by the server (32 MiB).
+    /// Larger bodies receive `413 Payload Too Large` and the connection is closed.
+    static let maxBodyBytes = 32 * 1024 * 1024
+    /// Maximum lifetime of a single HTTP connection from first byte to dispatch.
+    /// Prevents slow-loris clients from pinning sockets indefinitely.
+    static let requestTimeoutSeconds: Double = 30
+
     let port: UInt16
     let router: Router
     private let lock = NSLock()
@@ -29,7 +51,12 @@ final class HTTPServer: @unchecked Sendable {
     private var _onStateChange: ((Bool) -> Void)?
     private var _onReady: (() -> Void)?
 
-    init(port: UInt16 = 8420, router: Router) {
+    init(port: UInt16 = 8420, router: Router) throws {
+        // `UInt16` already constrains the upper bound (<= 65535); port 0 is
+        // the wildcard / "any port" sentinel and is never something we want
+        // to advertise via mDNS, so reject it explicitly rather than crashing
+        // inside `NWEndpoint.Port(rawValue:)` later.
+        guard port > 0 else { throw HTTPServerError.invalidPort(port) }
         self.port = port
         self.router = router
     }
@@ -46,12 +73,20 @@ final class HTTPServer: @unchecked Sendable {
     }
 
     func start() {
+        // `port` was validated at construction (>0 and <= 65535 by type), so
+        // `NWEndpoint.Port(rawValue:)` cannot fail — no force-unwrap needed.
+        guard let endpointPort = NWEndpoint.Port(rawValue: port) else {
+            print("[HTTPServer] Invalid port \(port) — refusing to start")
+            onBonjourStateChange?(false)
+            onStateChange?(false)
+            return
+        }
+
         let newListener: NWListener
         do {
             let params = NWParameters.tcp
             params.allowLocalEndpointReuse = true
-            // swiftlint:disable:next force_unwrapping
-            newListener = try NWListener(using: params, on: NWEndpoint.Port(rawValue: port)!)
+            newListener = try NWListener(using: params, on: endpointPort)
         } catch {
             print("[HTTPServer] Failed to create listener: \(error)")
             onBonjourStateChange?(false)
@@ -119,59 +154,132 @@ final class HTTPServer: @unchecked Sendable {
 
     private func handleConnection(_ connection: NWConnection) {
         connection.start(queue: .global(qos: .userInitiated))
-        receiveData(connection: connection, buffer: Data())
+        let deadline = Date().addingTimeInterval(Self.requestTimeoutSeconds)
+        receiveData(connection: connection, buffer: Data(), deadline: deadline)
     }
 
-    private func receiveData(connection: NWConnection, buffer: Data) {
+    /// Recursively drains `connection` into `buffer`, enforcing header-byte,
+    /// body-byte, and overall-deadline limits. Each invocation re-checks the
+    /// deadline before requesting more data so slow-loris clients are bounded.
+    private func receiveData(connection: NWConnection, buffer: Data, deadline: Date) {
+        if Date() >= deadline {
+            send408AndClose(connection: connection)
+            return
+        }
         connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] content, _, isComplete, error in
             guard let self else { return }
             var accumulated = buffer
             if let content { accumulated.append(content) }
 
             if isComplete || error != nil {
-                Task {
-                    await self.processRequest(connection: connection, data: accumulated)
-                }
-            } else if let headerEnd = accumulated.range(of: Data("\r\n\r\n".utf8)) {
-                let headerString = String(data: accumulated[..<headerEnd.lowerBound], encoding: .utf8) ?? ""
-                let contentLength = self.parseContentLength(headerString)
-                let bodyStart = headerEnd.upperBound
-                let bodyReceived = accumulated.distance(from: bodyStart, to: accumulated.endIndex)
-
-                if let contentLength, bodyReceived >= contentLength {
-                    Task { await self.processRequest(connection: connection, data: accumulated) }
-                } else if contentLength == nil {
-                    // Reject POSTs without Content-Length; GETs never have a body.
-                    let headerString2 = String(data: accumulated[..<headerEnd.lowerBound], encoding: .utf8) ?? ""
-                    let requestLine = headerString2.components(separatedBy: "\r\n").first ?? ""
-                    if requestLine.hasPrefix("POST ") {
-                        let body = Data("""
-                        {"error":"Content-Length required"}
-                        """.utf8)
-                        let response = self.buildHTTPResponse(
-                            statusCode: 411,
-                            body: body,
-                            contentType: "application/json"
-                        )
-                        connection.send(content: response, completion: .contentProcessed { _ in connection.cancel() })
-                    } else {
-                        Task { await self.processRequest(connection: connection, data: accumulated) }
-                    }
-                } else {
-                    self.receiveData(connection: connection, buffer: accumulated)
-                }
-            } else {
-                self.receiveData(connection: connection, buffer: accumulated)
+                Task { await self.processRequest(connection: connection, data: accumulated) }
+                return
             }
+
+            self.continueReceive(connection: connection, accumulated: accumulated, deadline: deadline)
         }
     }
 
-    private func parseContentLength(_ headers: String) -> Int? {
+    private func continueReceive(connection: NWConnection, accumulated: Data, deadline: Date) {
+        let headerSeparator = accumulated.range(of: Data("\r\n\r\n".utf8))
+
+        // Enforce header byte cap before headers complete. Closing early
+        // bounds slow-loris connections that drip a few bytes at a time.
+        if headerSeparator == nil, accumulated.count > Self.maxHeaderBytes {
+            send413AndClose(connection: connection, message: "Request header exceeds \(Self.maxHeaderBytes) bytes")
+            return
+        }
+
+        guard let headerEnd = headerSeparator else {
+            receiveData(connection: connection, buffer: accumulated, deadline: deadline)
+            return
+        }
+
+        let headerByteCount = accumulated.distance(from: accumulated.startIndex, to: headerEnd.lowerBound)
+        // Reject oversized headers even when they arrive in a single chunk —
+        // the headers-complete branch above only catches drip-feed clients.
+        if headerByteCount > Self.maxHeaderBytes {
+            send413AndClose(connection: connection, message: "Request header exceeds \(Self.maxHeaderBytes) bytes")
+            return
+        }
+
+        let headerString = String(data: accumulated[..<headerEnd.lowerBound], encoding: .utf8) ?? ""
+        let bodyStart = headerEnd.upperBound
+        let bodyReceived = accumulated.distance(from: bodyStart, to: accumulated.endIndex)
+
+        switch parseContentLength(headerString) {
+        case .valid(let contentLength):
+            if contentLength > Self.maxBodyBytes {
+                send413AndClose(
+                    connection: connection,
+                    message: "Content-Length \(contentLength) exceeds limit of \(Self.maxBodyBytes) bytes"
+                )
+                return
+            }
+            if bodyReceived >= contentLength {
+                Task { await self.processRequest(connection: connection, data: accumulated) }
+            } else {
+                receiveData(connection: connection, buffer: accumulated, deadline: deadline)
+            }
+        case .missing:
+            // Reject POSTs without Content-Length; GETs never have a body.
+            let requestLine = headerString.components(separatedBy: "\r\n").first ?? ""
+            if requestLine.hasPrefix("POST ") {
+                send411AndClose(connection: connection)
+            } else {
+                Task { await self.processRequest(connection: connection, data: accumulated) }
+            }
+        case .malformed:
+            send400AndClose(connection: connection, message: "Malformed Content-Length")
+        }
+    }
+
+    private enum ContentLengthParseResult {
+        case valid(Int)
+        case missing
+        case malformed
+    }
+
+    /// Strictly parses the `Content-Length` header. Rejects negatives,
+    /// non-integer values, and trailing garbage. RFC 7230 §3.3.2 requires
+    /// a non-negative decimal — `Int("-1")` parses successfully and used to
+    /// pass through as a body-size of -1, making `bodyReceived >= -1` always
+    /// true and short-circuiting the read loop.
+    private func parseContentLength(_ headers: String) -> ContentLengthParseResult {
         for line in headers.components(separatedBy: "\r\n") where line.lowercased().hasPrefix("content-length:") {
             let value = line.dropFirst("content-length:".count).trimmingCharacters(in: .whitespaces)
-            return Int(value)
+            guard !value.isEmpty, value.allSatisfy({ $0.isASCII && $0.isNumber }), let parsed = Int(value) else {
+                return .malformed
+            }
+            return .valid(parsed)
         }
-        return nil
+        return .missing
+    }
+
+    private func send408AndClose(connection: NWConnection) {
+        let body = Data(#"{"error":"Request timeout"}"#.utf8)
+        let response = buildHTTPResponse(statusCode: 408, body: body, contentType: "application/json")
+        connection.send(content: response, completion: .contentProcessed { _ in connection.cancel() })
+    }
+
+    private func send411AndClose(connection: NWConnection) {
+        let body = Data(#"{"error":"Content-Length required"}"#.utf8)
+        let response = buildHTTPResponse(statusCode: 411, body: body, contentType: "application/json")
+        connection.send(content: response, completion: .contentProcessed { _ in connection.cancel() })
+    }
+
+    private func send413AndClose(connection: NWConnection, message: String) {
+        let payload: [String: Any] = ["error": message]
+        let body = (try? JSONSerialization.data(withJSONObject: payload)) ?? Data(#"{"error":"Payload too large"}"#.utf8)
+        let response = buildHTTPResponse(statusCode: 413, body: body, contentType: "application/json")
+        connection.send(content: response, completion: .contentProcessed { _ in connection.cancel() })
+    }
+
+    private func send400AndClose(connection: NWConnection, message: String) {
+        let payload: [String: Any] = ["error": message]
+        let body = (try? JSONSerialization.data(withJSONObject: payload)) ?? Data(#"{"error":"Bad request"}"#.utf8)
+        let response = buildHTTPResponse(statusCode: 400, body: body, contentType: "application/json")
+        connection.send(content: response, completion: .contentProcessed { _ in connection.cancel() })
     }
 
     private func processRequest(connection: NWConnection, data: Data) async {
@@ -259,8 +367,10 @@ final class HTTPServer: @unchecked Sendable {
         switch statusCode {
         case 200: statusText = "OK"
         case 400: statusText = "Bad Request"
-        case 411: statusText = "Length Required"
         case 404: statusText = "Not Found"
+        case 408: statusText = "Request Timeout"
+        case 411: statusText = "Length Required"
+        case 413: statusText = "Payload Too Large"
         case 500: statusText = "Internal Server Error"
         default: statusText = "Unknown"
         }

--- a/apps/macos/Kelpie/Network/ServerState.swift
+++ b/apps/macos/Kelpie/Network/ServerState.swift
@@ -18,7 +18,11 @@ final class ServerState: ObservableObject {
     let handlerContext = HandlerContext()
     let scriptPlaybackState = ScriptPlaybackState()
 
-    var rendererState: RendererState?
+    /// The renderer state is supplied to `startHTTPServer(rendererState:)`.
+    /// Optional only because the view-model is created before the view layer
+    /// constructs `RendererState`. Once HTTP serving begins, it is guaranteed
+    /// non-nil because `startHTTPServer` stores it before `registerHandlers()`.
+    private(set) var rendererState: RendererState?
 
     // Renderers are created on first use and cached for instant switching
     var wkRenderer: WKWebViewRenderer?
@@ -44,7 +48,12 @@ final class ServerState: ObservableObject {
         self.ipAddress = Self.getLocalIPAddress()
     }
 
-    func startHTTPServer() {
+    /// Starts the HTTP server and binds the supplied renderer state into
+    /// every handler that needs it. The renderer state must be supplied
+    /// here (not as a separate property assignment) so handler registration
+    /// can read it without force-unwrapping.
+    func startHTTPServer(rendererState: RendererState) {
+        self.rendererState = rendererState
         let preferredPort = UInt16(deviceInfo.port)
         let resolvedPort = Self.firstAvailablePort(startingAt: preferredPort)
         if Int(resolvedPort) != deviceInfo.port {
@@ -61,13 +70,21 @@ final class ServerState: ObservableObject {
 
         // Start only the selected renderer (browser instance). CEF is
         // initialized above but no Chromium browser is created yet.
-        let startEngine = rendererState?.activeEngine ?? .webkit
+        let startEngine = rendererState.activeEngine
         let activeRenderer = renderer(for: startEngine)
         handlerContext.renderer = activeRenderer
         handlerContext.startSharedCookieSync()
 
-        registerHandlers()
-        let server = HTTPServer(port: resolvedPort, router: router)
+        registerHandlers(rendererState: rendererState)
+        let server: HTTPServer
+        do {
+            server = try HTTPServer(port: resolvedPort, router: router)
+        } catch {
+            print("[ServerState] Failed to construct HTTPServer for port \(resolvedPort): \(error)")
+            isServerRunning = false
+            isMDNSAdvertising = false
+            return
+        }
         server.onBonjourStateChange = { [weak self] isAdvertising in
             Task { @MainActor in
                 self?.isMDNSAdvertising = isAdvertising
@@ -90,7 +107,7 @@ final class ServerState: ObservableObject {
         httpServer?.start()
     }
 
-    private func registerHandlers() {
+    private func registerHandlers(rendererState: RendererState) {
         let ctx = handlerContext
         ctx.scriptPlaybackState = scriptPlaybackState
         router.handlerContext = ctx
@@ -111,8 +128,7 @@ final class ServerState: ObservableObject {
         DeviceHandler(
             context: ctx,
             deviceInfo: deviceInfo,
-            // swiftlint:disable:next force_unwrapping
-            rendererState: rendererState!,
+            rendererState: rendererState,
             viewportState: viewportState
         ).register(on: router)
         EvaluateHandler(context: ctx).register(on: router)
@@ -143,8 +159,7 @@ final class ServerState: ObservableObject {
         // Renderer switching handler
         RendererHandler(
             context: ctx,
-            // swiftlint:disable:next force_unwrapping
-            rendererState: rendererState!,
+            rendererState: rendererState,
             onSwitch: { [weak self] engine in
                 await self?.switchRenderer(to: engine)
             }

--- a/apps/macos/Kelpie/Renderer/CEFRenderer.swift
+++ b/apps/macos/Kelpie/Renderer/CEFRenderer.swift
@@ -240,7 +240,11 @@ final class CEFRenderer: RendererEngine {
     func hardReload() { bridge?.reloadIgnoringCache() }
 
     func evaluateJS(_ script: String) async throws -> Any? {
-        guard !containerView.isHidden else { return nil }
+        // Returning `nil` here would be silently coerced into "empty result"
+        // by the handler layer (HandlerContext.evaluateJSReturningJSON returns
+        // `[:]` for non-JSON output), making callers think the script ran when
+        // the renderer was actually hidden. Throw so the response surfaces.
+        guard !containerView.isHidden else { throw HandlerError.rendererHidden }
         guard let bridge else { throw HandlerError.noWebView }
         return try await withCheckedThrowingContinuation { continuation in
             bridge.evaluateJavaScript(script) { result, error in


### PR DESCRIPTION
## Summary

Hardens the macOS app's HTTP entry surface and removes five silent-failure / force-unwrap bugs.

### Fixes

**1. HTTPServer port validation (CRITICAL, crash risk)**
`HTTPServer.init(port:router:)` now throws `HTTPServerError.invalidPort(UInt16)` for port 0. The previous `NWEndpoint.Port(rawValue: port)!` crashed the app on launch with port 0 misconfig. `ServerState.startHTTPServer` catches the error and aborts startup cleanly.

**2. Non-optional rendererState wiring (HIGH)**
`ServerState.startHTTPServer(rendererState:)` now takes `rendererState` as a parameter and stores it before any handler reads it, eliminating both `rendererState!` force-unwraps in handler registration. `KelpieApp` updated to pass it directly instead of as a separate property assignment.

**3. Request size limits + slow-loris protection (HIGH)**
- 16 KiB header byte cap (drip-feed + single-chunk both rejected) → `413 Payload Too Large`.
- 32 MiB body cap → `413` when `Content-Length` exceeds it.
- Strict `Content-Length` parsing rejects negatives, non-decimal, and empty values → `400 Bad Request`. Previous `Int("-1")` parsed successfully, making the read-completion check `bodyReceived >= -1` always true.
- 30s overall request deadline → `408 Request Timeout`. Bounds slow-loris.
- `408` / `413` status lines added to the response builder.

**4. typeText error propagation (HIGH)**
`InteractionHandler.typeText` per-character keystrokes and the finalize event now use `try` inside a do/catch returning `TAB_NOT_FOUND` / `TAB_REQUIRED` / `TYPING_FAILED` structured errors. Dropped keystrokes no longer silently report `success: true`.

**5. CEFRenderer.evaluateJS while hidden (MEDIUM)**
`CEFRenderer.evaluateJS` now throws `HandlerError.rendererHidden` instead of returning `nil` when the view is hidden. The shared `tabErrorResponse` helper maps it to `RENDERER_HIDDEN`, so every handler that routes errors through that helper produces a structured response rather than the previous empty `[:]` lie.

### Verification

`make lint-swift` — 0 violations across 161 files.

`xcodebuild -workspace apps/macos/Kelpie.xcworkspace -scheme Kelpie -destination 'platform=macOS' build` — BUILD SUCCEEDED.

Runtime smoke test against the launched app (bound on 8431 due to local port collision with parallel testing):

| Request                                                   | Result |
| --------------------------------------------------------- | ------ |
| `GET /health`                                             | 200    |
| `POST` with `Content-Length: 99999999999`                 | 413 (`{"error":"Content-Length 99999999999 exceeds limit of 33554432 bytes"}`) |
| `POST` with 20 KiB of header padding                      | 413 (`{"error":"Request header exceeds 16384 bytes"}`) |
| `POST` with `Content-Length: -1`                          | 400 (`{"error":"Malformed Content-Length"}`) |
| `POST` without `Content-Length`                           | 411 (`{"error":"Content-Length required"}`) |
| Slow-loris drip-feed for 35s                              | 408 at ~30s (`{"error":"Request timeout"}`) |
| `POST /v1/get-current-url`                                | 200 |

## Test plan

- [x] `make lint-swift` passes
- [x] `xcodebuild ... build` succeeds, no warnings introduced
- [x] Runtime smoke test: 413 for oversize Content-Length, 413 for oversize header, 400 for malformed Content-Length, 411 for missing Content-Length on POST, 408 for slow-loris, 200 for normal POST/GET
- [ ] (follow-up) confirm typeText returns `TYPING_FAILED` against a real renderer reset mid-typing
- [ ] (follow-up) confirm hidden-CEF tab evaluateJS returns `RENDERER_HIDDEN` via the CLI

## Notes

- Did not modify `BrowserManagementHandler.swift` (owned by parallel branch).
- Did not bump versions.
- Did not touch iOS / Android / CLI.
- Two touched files (`CEFRenderer.swift`, `HandlerContext.swift`) were already over the 500-line limit before this PR; the rule violation is pre-existing. My delta is +4 and +8 lines respectively — splitting them is out of scope for this hardening pass.