### PR TITLE
fix(ios): retain cycles, file protection, LAN Info.plist keys, Safari auth errors

### DIFF
--- a/apps/ios/Kelpie/Browser/ExternalDisplayManager.swift
+++ b/apps/ios/Kelpie/Browser/ExternalDisplayManager.swift
@@ -164,11 +164,12 @@ final class ExternalDisplayManager: ObservableObject {
         config.websiteDataStore = WebViewDefaults.sharedWebsiteDataStore
 
         let ucc = config.userContentController
+        let proxy = WeakScriptMessageHandler(serverState.handlerContext)
         ucc.addUserScript(NetworkBridge.bridgeScript)
-        ucc.add(serverState.handlerContext, name: "kelpieNetwork")
+        ucc.add(proxy, name: "kelpieNetwork")
         ucc.addUserScript(WebSocketBridge.bridgeScript)
         ucc.addUserScript(ConsoleHandler.bridgeScript)
-        ucc.add(serverState.handlerContext, name: "kelpieConsole")
+        ucc.add(proxy, name: "kelpieConsole")
 
         return config
     }

--- a/apps/ios/Kelpie/Browser/SafariAuthHelper.swift
+++ b/apps/ios/Kelpie/Browser/SafariAuthHelper.swift
@@ -2,32 +2,64 @@ import AuthenticationServices
 import UIKit
 import WebKit
 
+/// Errors thrown while running a Safari-backed authentication session.
+enum SafariAuthError: Error {
+    /// The webView reference was nil at completion (tab closed, view torn down).
+    case webViewUnavailable
+    /// The system reported a failure from `ASWebAuthenticationSession`. The
+    /// underlying error is preserved verbatim — common cases include the user
+    /// cancelling the sheet and the session failing to present.
+    case session(Error)
+}
+
 /// Opens the current page URL in an ASWebAuthenticationSession (Safari-backed sheet)
 /// so the user can authenticate with Safari's saved passwords and cookies,
 /// then syncs cookies back into the WKWebView.
+///
+/// Errors from the underlying session are propagated through `authenticate` —
+/// callers can surface cancellations or presentation failures rather than
+/// silently treating them as success. Cookie sync still runs on success.
 @MainActor
 final class SafariAuthHelper: NSObject, ASWebAuthenticationPresentationContextProviding {
     private var session: ASWebAuthenticationSession?
     private weak var webView: WKWebView?
 
-    func authenticate(url: URL, webView: WKWebView) {
+    /// Starts the Safari authentication sheet. Resumes when the user dismisses
+    /// the sheet (or the system tears it down). Throws if the session fails or
+    /// the webView is no longer available for cookie sync.
+    func authenticate(url: URL, webView: WKWebView) async throws {
         self.webView = webView
 
-        // callbackURLScheme: nil — no redirect expected. The user logs in,
-        // taps Done, and the completion fires so we can sync cookies + reload.
-        let session = ASWebAuthenticationSession(url: url, callbackURLScheme: nil) { [weak self] _, _ in
-            Task { @MainActor in
-                await self?.syncCookiesAndReload()
+        let outcome: Result<URL?, Error> = await withCheckedContinuation { continuation in
+            // callbackURLScheme: nil — no redirect expected. The user logs in,
+            // taps Done, and the completion fires so we can sync cookies + reload.
+            let session = ASWebAuthenticationSession(url: url, callbackURLScheme: nil) { callbackURL, error in
+                if let error {
+                    continuation.resume(returning: .failure(error))
+                } else {
+                    continuation.resume(returning: .success(callbackURL))
+                }
             }
+            session.prefersEphemeralWebBrowserSession = false // share Safari's cookies + passwords
+            session.presentationContextProvider = self
+            self.session = session
+            session.start()
         }
-        session.prefersEphemeralWebBrowserSession = false // share Safari's cookies + passwords
-        session.presentationContextProvider = self
-        self.session = session
-        session.start()
+
+        defer { self.session = nil }
+
+        switch outcome {
+        case .failure(let underlying):
+            throw SafariAuthError.session(underlying)
+        case .success:
+            guard let webView = self.webView else {
+                throw SafariAuthError.webViewUnavailable
+            }
+            await syncCookiesAndReload(webView: webView)
+        }
     }
 
-    private func syncCookiesAndReload() async {
-        guard let webView else { return }
+    private func syncCookiesAndReload(webView: WKWebView) async {
         let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
 
         // ASWebAuthenticationSession with prefersEphemeralWebBrowserSession=false

--- a/apps/ios/Kelpie/Browser/TabStore.swift
+++ b/apps/ios/Kelpie/Browser/TabStore.swift
@@ -87,12 +87,13 @@ final class TabStore: ObservableObject {
 
         if let handlerContext {
             let ucc = config.userContentController
+            let proxy = WeakScriptMessageHandler(handlerContext)
             ucc.addUserScript(NetworkBridge.bridgeScript)
-            ucc.add(handlerContext, name: "kelpieNetwork")
+            ucc.add(proxy, name: "kelpieNetwork")
             ucc.addUserScript(WebSocketBridge.bridgeScript)
             ucc.addUserScript(ConsoleHandler.bridgeScript)
-            ucc.add(handlerContext, name: "kelpieConsole")
-            ucc.add(handlerContext, name: "kelpie3DSnapshot")
+            ucc.add(proxy, name: "kelpieConsole")
+            ucc.add(proxy, name: "kelpie3DSnapshot")
         }
 
         let webView = WKWebView(frame: .zero, configuration: config)

--- a/apps/ios/Kelpie/Browser/WebViewCoordinator.swift
+++ b/apps/ios/Kelpie/Browser/WebViewCoordinator.swift
@@ -19,12 +19,13 @@ struct WebViewContainer: UIViewRepresentable {
         // Inject bridge scripts — network bridge FIRST (saves postMessage ref before console bridge masks messageHandlers)
         if let handlerContext {
             let ucc = config.userContentController
+            let proxy = WeakScriptMessageHandler(handlerContext)
             ucc.addUserScript(NetworkBridge.bridgeScript)
-            ucc.add(handlerContext, name: "kelpieNetwork")
+            ucc.add(proxy, name: "kelpieNetwork")
             ucc.addUserScript(WebSocketBridge.bridgeScript)
             ucc.addUserScript(ConsoleHandler.bridgeScript)
-            ucc.add(handlerContext, name: "kelpieConsole")
-            ucc.add(handlerContext, name: "kelpie3DSnapshot")
+            ucc.add(proxy, name: "kelpieConsole")
+            ucc.add(proxy, name: "kelpie3DSnapshot")
         }
 
         let webView = WKWebView(frame: .zero, configuration: config)

--- a/apps/ios/Kelpie/Handlers/AIHandler.swift
+++ b/apps/ios/Kelpie/Handlers/AIHandler.swift
@@ -13,6 +13,10 @@ struct AIHandler {
         let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("models", isDirectory: true)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        // AI model blobs are persistent user data; apply NSFileProtectionComplete
+        // to the directory so downloaded weights and any sidecar files inherit
+        // the strongest protection class while the device is locked.
+        try? FileProtection.setComplete(at: dir)
         return AIManager(modelsDir: dir.path)
     }()
 

--- a/apps/ios/Kelpie/Handlers/ScriptHandler.swift
+++ b/apps/ios/Kelpie/Handlers/ScriptHandler.swift
@@ -306,6 +306,10 @@ struct ScriptHandler {
         let ext = format == "jpeg" ? "jpg" : "png"
         let file = FileManager.default.temporaryDirectory
             .appendingPathComponent("kelpie-script-\(index)-\(UUID().uuidString).\(ext)")
+        // Intentionally NOT NSFileProtectionComplete-tagged: these are ephemeral
+        // playback artefacts in tmp/ that iOS may delete at any time and that
+        // never outlive the playback request. Persistent screenshots go through
+        // a different path that does apply file protection.
         do {
             try data.write(to: file)
             return ScriptPlaybackScreenshot(

--- a/apps/ios/Kelpie/Handlers/WeakScriptMessageHandler.swift
+++ b/apps/ios/Kelpie/Handlers/WeakScriptMessageHandler.swift
@@ -1,0 +1,25 @@
+import WebKit
+
+/// Weak proxy for `WKScriptMessageHandler` registrations.
+///
+/// `WKUserContentController.add(_:name:)` retains the handler strongly. When the
+/// registered handler also retains the `WKWebView` (directly or via a coordinator
+/// that owns it), this creates a retain cycle that prevents the WKWebView from
+/// being released — bridge scripts keep running, tabs leak, and memory grows
+/// across navigations.
+///
+/// `WeakScriptMessageHandler` holds the real target weakly so the cycle is
+/// broken: registrar -> proxy (strong) -> target (weak) -> webView (strong).
+/// Closing the tab releases the target; the proxy then becomes a harmless no-op.
+final class WeakScriptMessageHandler: NSObject, WKScriptMessageHandler {
+    private weak var target: WKScriptMessageHandler?
+
+    init(_ target: WKScriptMessageHandler) {
+        self.target = target
+        super.init()
+    }
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        target?.userContentController(userContentController, didReceive: message)
+    }
+}

--- a/apps/ios/Kelpie/Network/FeedbackStore.swift
+++ b/apps/ios/Kelpie/Network/FeedbackStore.swift
@@ -24,8 +24,13 @@ enum FeedbackStore {
         ]) { _, new in new }
 
         let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
-        try FileManager.default.createDirectory(at: feedbackDirectory(), withIntermediateDirectories: true)
-        try data.write(to: feedbackDirectory().appendingPathComponent("\(storedAt.replacingOccurrences(of: ":", with: "-"))-\(reportID).json"))
+        let directory = feedbackDirectory()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        // Mark the directory NSFileProtectionComplete so any future report
+        // inherits the protection class even if a write path forgets to set it.
+        try? FileProtection.setComplete(at: directory)
+        let file = directory.appendingPathComponent("\(storedAt.replacingOccurrences(of: ":", with: "-"))-\(reportID).json")
+        try FileProtection.write(data, to: file)
         return FeedbackRecord(reportID: reportID, storedAt: storedAt, payload: payload)
     }
 

--- a/apps/ios/Kelpie/Network/FileProtection.swift
+++ b/apps/ios/Kelpie/Network/FileProtection.swift
@@ -29,9 +29,9 @@ enum FileProtection {
     /// cheapest way to protect everything subsequently written there
     /// (e.g. downloaded AI models, persisted feedback reports).
     static func setComplete(at url: URL) throws {
-        var values = URLResourceValues()
-        values.fileProtection = .complete
-        var mutable = url
-        try mutable.setResourceValues(values)
+        try FileManager.default.setAttributes(
+            [.protectionKey: FileProtectionType.complete],
+            ofItemAtPath: url.path
+        )
     }
 }

--- a/apps/ios/Kelpie/Network/FileProtection.swift
+++ b/apps/ios/Kelpie/Network/FileProtection.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Applies iOS Data Protection so files written by Kelpie are encrypted while
+/// the device is locked.
+///
+/// `NSFileProtectionComplete` is the strongest class: the file's encryption key
+/// is evicted from memory shortly after the device locks, so the contents are
+/// unreadable until the user next unlocks. This is the correct default for any
+/// persistent user data — bookmarks, history, sessions, feedback, AI models,
+/// settings — that an offline attacker could otherwise lift off a stolen device.
+///
+/// Ephemeral caches (e.g. transient screenshots in `tmp/`) are intentionally
+/// left at the system default because they have no long-term threat model;
+/// their call sites document the decision inline.
+enum FileProtection {
+    /// Writes `data` to `url` and tags the file with `NSFileProtectionComplete`.
+    ///
+    /// Uses `Data.write(to:options:)` with `.completeFileProtection` so the
+    /// protection class is applied atomically with the write — there is no
+    /// window during which the file exists at a weaker class.
+    static func write(_ data: Data, to url: URL) throws {
+        try data.write(to: url, options: [.atomic, .completeFileProtection])
+    }
+
+    /// Sets `NSFileProtectionComplete` on an existing file or directory.
+    ///
+    /// New files created inside a protected directory inherit the parent's
+    /// class, so applying this to a directory after `createDirectory` is the
+    /// cheapest way to protect everything subsequently written there
+    /// (e.g. downloaded AI models, persisted feedback reports).
+    static func setComplete(at url: URL) throws {
+        var values = URLResourceValues()
+        values.fileProtection = .complete
+        var mutable = url
+        try mutable.setResourceValues(values)
+    }
+}

--- a/apps/ios/Kelpie/Network/ServerState.swift
+++ b/apps/ios/Kelpie/Network/ServerState.swift
@@ -93,16 +93,34 @@ final class ServerState: ObservableObject {
     @MainActor
     private func registerSafariAuthHandler(context: HandlerContext) {
         router.register("safari-auth") { body in
-            await MainActor.run {
-                guard let webView = context.webView else {
-                    return errorResponse(code: "NO_WEBVIEW", message: "No WebView")
-                }
+            let resolved: (WKWebView, URL)? = await MainActor.run {
+                guard let webView = context.webView else { return nil }
                 let urlString = body["url"] as? String
                 guard let url = urlString.flatMap({ URL(string: $0) }) ?? webView.url else {
-                    return errorResponse(code: "NO_URL", message: "No URL to authenticate")
+                    return nil
                 }
-                context.safariAuth.authenticate(url: url, webView: webView)
-                return successResponse(["started": true, "url": url.absoluteString])
+                return (webView, url)
+            }
+
+            guard let (webView, url) = resolved else {
+                if await MainActor.run(body: { context.webView }) == nil {
+                    return errorResponse(code: "NO_WEBVIEW", message: "No WebView")
+                }
+                return errorResponse(code: "NO_URL", message: "No URL to authenticate")
+            }
+
+            do {
+                try await context.safariAuth.authenticate(url: url, webView: webView)
+                return successResponse(["completed": true, "url": url.absoluteString])
+            } catch SafariAuthError.webViewUnavailable {
+                return errorResponse(code: "NO_WEBVIEW", message: "WebView released before auth completion")
+            } catch SafariAuthError.session(let underlying) {
+                return errorResponse(
+                    code: "SAFARI_AUTH_FAILED",
+                    message: underlying.localizedDescription
+                )
+            } catch {
+                return errorResponse(code: "SAFARI_AUTH_FAILED", message: error.localizedDescription)
             }
         }
     }

--- a/apps/ios/Kelpie/Views/BrowserView.swift
+++ b/apps/ios/Kelpie/Views/BrowserView.swift
@@ -571,7 +571,17 @@ struct BrowserView: View {
 
     private func authenticateInSafari() {
         guard let webView = browserState.webView, let url = webView.url else { return }
-        safariAuth.authenticate(url: url, webView: webView)
+        Task { @MainActor in
+            do {
+                try await safariAuth.authenticate(url: url, webView: webView)
+            } catch SafariAuthError.session(let underlying) {
+                await serverState.handlerContext.showToast("Safari sign-in failed: \(underlying.localizedDescription)")
+            } catch SafariAuthError.webViewUnavailable {
+                await serverState.handlerContext.showToast("Safari sign-in cancelled: tab closed")
+            } catch {
+                await serverState.handlerContext.showToast("Safari sign-in failed: \(error.localizedDescription)")
+            }
+        }
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

Fixes four HIGH-severity iOS-only findings from the round-2 audit.

### 1. WKScriptMessageHandler retain cycles
`WKUserContentController.add(_:name:)` retains the script handler strongly. When the handler also retains the WKWebView (directly or via a coordinator), closed tabs and their WKWebViews never deallocate, leaking memory and keeping bridge scripts running.

Introduced ``WeakScriptMessageHandler`` — a proxy that forwards messages to a weakly-held target — and registered it at every ``add(_:name:)`` site: ``WebViewCoordinator.swift``, ``TabStore.swift``, ``ExternalDisplayManager.swift``.

### 2. NSFileProtectionComplete on persistent stores
iOS's default protection class still leaves files readable after first unlock since boot. For persistent user data we now apply ``NSFileProtectionComplete``:

- New ``FileProtection`` helper with ``write(_:to:)`` (atomic write with ``.completeFileProtection``) and ``setComplete(at:)`` (via ``FileManager.setAttributes`` + ``protectionKey``).
- ``FeedbackStore`` writes reports through the helper and tags the parent directory.
- ``AIHandler`` tags the ``Documents/models/`` directory on creation so downloaded weights inherit the strongest class.
- ``ScriptHandler`` tmp-screenshot path documents the intentional skip (ephemeral, no long-term threat model).
- Bookmarks, history, sessions, and traffic already live in UserDefaults — no per-file change needed.

### 3. Info.plist LAN keys
Verified: ``NSLocalNetworkUsageDescription`` is set and ``NSBonjourServices`` contains ``_kelpie._tcp``. No change required — already present from a prior fix.

### 4. SafariAuthHelper error propagation
The completion handler previously discarded both the callback URL and the error from ``ASWebAuthenticationSession``, so cancellations and presentation failures looked identical to success.

- ``SafariAuthHelper.authenticate`` is now async-throwing and reports ``SafariAuthError.session`` / ``.webViewUnavailable``.
- The ``safari-auth`` HTTP route returns ``SAFARI_AUTH_FAILED`` / ``NO_WEBVIEW`` and only reports success once cookies have been synced + the page reloaded.
- ``BrowserView``'s Safari menu item surfaces failures as a toast.

## Verification

- ``make lint-swift`` — 0 violations across 163 files
- ``tuist generate`` in ``apps/ios`` — clean
- ``xcodebuild -workspace Kelpie.xcworkspace -scheme Kelpie -destination "generic/platform=iOS Simulator" -configuration Debug build CODE_SIGNING_ALLOWED=NO`` — **BUILD SUCCEEDED** (only pre-existing AccentColor warning)

## Test plan

- [ ] Open several tabs, close them, confirm WKWebViews deallocate (no growing memory across cycles)
- [ ] Submit feedback report on device; confirm the file under ``Application Support/Kelpie/feedback/`` is tagged ``NSFileProtectionComplete``
- [ ] Download an AI model; confirm ``Documents/models/`` is tagged ``NSFileProtectionComplete``
- [ ] Trigger Safari auth, cancel mid-flow; confirm a failure toast appears (UI path) and the HTTP route returns ``SAFARI_AUTH_FAILED`` (CLI path)
- [ ] First-launch on iOS 14+ shows the local-network permission prompt and CLI discovery works

Do not merge — awaiting integration review.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>