### PR TITLE
fix: enforce HTTP body/header size limits on iOS/Android/macOS

### DIFF
--- a/apps/android/app/src/main/java/com/kelpie/browser/network/HTTPServer.kt
+++ b/apps/android/app/src/main/java/com/kelpie/browser/network/HTTPServer.kt
@@ -3,6 +3,7 @@ package com.kelpie.browser.network
 import android.content.Context
 import android.util.Log
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.call
@@ -40,13 +41,40 @@ class HTTPServer(
     private val router: Router,
     private val appContext: Context,
 ) {
+    companion object {
+        /**
+         * Maximum request body size accepted by the server (50 MiB).
+         * Larger bodies receive `413 Payload Too Large` and the connection is closed.
+         * Mirrors iOS and macOS.
+         */
+        const val MAX_BODY_BYTES: Long = 50L * 1024L * 1024L
+
+        /**
+         * Maximum bytes accepted for HTTP request headers before parsing must complete.
+         * 64 KiB caps slow-loris pinning while leaving room for cookies and auth headers.
+         * Mirrors iOS and macOS.
+         */
+        const val MAX_HEADER_BYTES: Int = 64 * 1024
+    }
+
     private var engine: NettyApplicationEngine? = null
     var isRunning = false
         private set
 
     fun start() {
         engine =
-            embeddedServer(Netty, port = port) {
+            embeddedServer(
+                factory = Netty,
+                port = port,
+                configure = {
+                    // Cap request line + header bytes at the Netty layer so
+                    // oversized headers never make it as far as the routing
+                    // pipeline. Netty returns 431 automatically for overflow.
+                    maxInitialLineLength = MAX_HEADER_BYTES
+                    maxHeaderSize = MAX_HEADER_BYTES
+                    maxChunkSize = 64 * 1024
+                },
+            ) {
                 install(ContentNegotiation) { json(json) }
 
                 routing {
@@ -63,8 +91,53 @@ class HTTPServer(
                     }
 
                     post("/v1/{method}") {
+                        // Validate Content-Length BEFORE reading the body to
+                        // ensure a single malicious multi-GB POST never gets
+                        // buffered. Missing Content-Length on POST is rejected.
+                        val contentLengthHeader = call.request.headers[HttpHeaders.ContentLength]
+                        val contentLength = contentLengthHeader?.toLongOrNull()
+                        if (contentLengthHeader == null) {
+                            respondError(
+                                call = call,
+                                statusCode = HttpStatusCode.LengthRequired,
+                                code = "LENGTH_REQUIRED",
+                                message = "Content-Length header is required",
+                            )
+                            return@post
+                        }
+                        if (contentLength == null || contentLength < 0) {
+                            respondError(
+                                call = call,
+                                statusCode = HttpStatusCode.BadRequest,
+                                code = "BAD_REQUEST",
+                                message = "Malformed Content-Length",
+                            )
+                            return@post
+                        }
+                        if (contentLength > MAX_BODY_BYTES) {
+                            respondError(
+                                call = call,
+                                statusCode = HttpStatusCode.PayloadTooLarge,
+                                code = "PAYLOAD_TOO_LARGE",
+                                message = "Request body exceeds ${MAX_BODY_BYTES / 1024 / 1024} MB limit",
+                            )
+                            return@post
+                        }
+
                         val method = call.parameters["method"] ?: ""
                         val bodyText = call.receiveText()
+                        // Defense-in-depth: if the client under-declared
+                        // Content-Length and streamed more bytes, reject.
+                        if (bodyText.toByteArray(Charsets.UTF_8).size.toLong() > MAX_BODY_BYTES) {
+                            respondError(
+                                call = call,
+                                statusCode = HttpStatusCode.PayloadTooLarge,
+                                code = "PAYLOAD_TOO_LARGE",
+                                message = "Request body exceeds ${MAX_BODY_BYTES / 1024 / 1024} MB limit",
+                            )
+                            return@post
+                        }
+
                         val body =
                             parseJsonBody(bodyText)
                                 ?: return@post call.respondText(
@@ -141,4 +214,17 @@ class HTTPServer(
             is List<*> -> kotlinx.serialization.json.JsonArray(value.map { anyToJsonElement(it) })
             else -> JsonPrimitive(value.toString())
         }
+
+    private suspend fun respondError(
+        call: io.ktor.server.application.ApplicationCall,
+        statusCode: HttpStatusCode,
+        code: String,
+        message: String,
+    ) {
+        call.respondText(
+            text = mapToJsonString(errorResponse(code, message)),
+            contentType = ContentType.Application.Json,
+            status = statusCode,
+        )
+    }
 }

--- a/apps/ios/Kelpie/Network/HTTPServer.swift
+++ b/apps/ios/Kelpie/Network/HTTPServer.swift
@@ -1,6 +1,18 @@
 import Foundation
 import Network
 
+/// Errors thrown by HTTPServer for unrecoverable startup conditions.
+enum HTTPServerError: Error, CustomStringConvertible {
+    case invalidPort(UInt16)
+
+    var description: String {
+        switch self {
+        case .invalidPort(let port):
+            return "Invalid HTTP server port: \(port)"
+        }
+    }
+}
+
 /// Embedded HTTP server for receiving CLI commands.
 /// Uses raw NWListener since we want zero external dependencies for the server.
 ///
@@ -10,23 +22,40 @@ import Network
 /// listener is bound to, so advertising via a second standalone listener would
 /// announce an ephemeral port that no one is serving on.
 final class HTTPServer: @unchecked Sendable {
+    /// Maximum bytes accepted for HTTP request headers before parsing must complete.
+    /// 64 KiB caps slow-loris pinning while leaving room for cookies and auth headers.
+    /// Mirrors macOS and Android.
+    static let maxHeaderBytes = 64 * 1024
+    /// Maximum request body size accepted by the server (50 MiB).
+    /// Larger bodies receive `413 Payload Too Large` and the connection is closed.
+    /// Mirrors macOS and Android.
+    static let maxBodyBytes = 50 * 1024 * 1024
+    /// Maximum lifetime of a single HTTP connection from first byte to dispatch.
+    /// Prevents slow-loris clients from pinning sockets indefinitely.
+    static let requestTimeoutSeconds: Double = 30
+
     let port: UInt16
     let router: Router
     private var listener: NWListener?
     private var pendingService: NWListener.Service?
     var serviceRegistrationUpdateHandler: ((NWListener.ServiceRegistrationChange) -> Void)?
 
-    init(port: UInt16 = 8420, router: Router) {
+    init(port: UInt16 = 8420, router: Router) throws {
+        guard port > 0 else { throw HTTPServerError.invalidPort(port) }
         self.port = port
         self.router = router
     }
 
     func start() {
+        guard let endpointPort = NWEndpoint.Port(rawValue: port) else {
+            print("[HTTPServer] Invalid port \(port) — refusing to start")
+            return
+        }
+
         do {
             let params = NWParameters.tcp
             params.allowLocalEndpointReuse = true
-            // swiftlint:disable:next force_unwrapping
-            listener = try NWListener(using: params, on: NWEndpoint.Port(rawValue: port)!)
+            listener = try NWListener(using: params, on: endpointPort)
         } catch {
             print("[HTTPServer] Failed to create listener: \(error)")
             return
@@ -71,44 +100,166 @@ final class HTTPServer: @unchecked Sendable {
 
     private func handleConnection(_ connection: NWConnection) {
         connection.start(queue: .global(qos: .userInitiated))
-        receiveData(connection: connection, buffer: Data())
+        let deadline = Date().addingTimeInterval(Self.requestTimeoutSeconds)
+        receiveData(connection: connection, buffer: Data(), deadline: deadline)
     }
 
-    private func receiveData(connection: NWConnection, buffer: Data) {
+    /// Recursively drains `connection` into `buffer`, enforcing header-byte,
+    /// body-byte, and overall-deadline limits. Each invocation re-checks the
+    /// deadline before requesting more data so slow-loris clients are bounded.
+    private func receiveData(connection: NWConnection, buffer: Data, deadline: Date) {
+        if Date() >= deadline {
+            send408AndClose(connection: connection)
+            return
+        }
         connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] content, _, isComplete, error in
             guard let self else { return }
             var accumulated = buffer
             if let content { accumulated.append(content) }
 
             if isComplete || error != nil {
-                Task {
-                    await self.processRequest(connection: connection, data: accumulated)
-                }
-            } else if let headerEnd = accumulated.range(of: Data("\r\n\r\n".utf8)) {
-                let headerString = String(data: accumulated[..<headerEnd.lowerBound], encoding: .utf8) ?? ""
-                let contentLength = self.parseContentLength(headerString)
-                let bodyStart = headerEnd.upperBound
-                let bodyReceived = accumulated.distance(from: bodyStart, to: accumulated.endIndex)
-
-                if bodyReceived >= contentLength {
-                    Task {
-                        await self.processRequest(connection: connection, data: accumulated)
-                    }
-                } else {
-                    self.receiveData(connection: connection, buffer: accumulated)
-                }
-            } else {
-                self.receiveData(connection: connection, buffer: accumulated)
+                Task { await self.processRequest(connection: connection, data: accumulated) }
+                return
             }
+
+            self.continueReceive(connection: connection, accumulated: accumulated, deadline: deadline)
         }
     }
 
-    private func parseContentLength(_ headers: String) -> Int {
+    private func continueReceive(connection: NWConnection, accumulated: Data, deadline: Date) {
+        let headerSeparator = accumulated.range(of: Data("\r\n\r\n".utf8))
+
+        // Enforce header byte cap before headers complete. Closing early
+        // bounds slow-loris connections that drip a few bytes at a time.
+        if headerSeparator == nil, accumulated.count > Self.maxHeaderBytes {
+            send431HeaderAndClose(connection: connection)
+            return
+        }
+
+        guard let headerEnd = headerSeparator else {
+            receiveData(connection: connection, buffer: accumulated, deadline: deadline)
+            return
+        }
+
+        let headerByteCount = accumulated.distance(from: accumulated.startIndex, to: headerEnd.lowerBound)
+        // Reject oversized headers even when they arrive in a single chunk —
+        // the headers-complete branch above only catches drip-feed clients.
+        if headerByteCount > Self.maxHeaderBytes {
+            send431HeaderAndClose(connection: connection)
+            return
+        }
+
+        let headerString = String(data: accumulated[..<headerEnd.lowerBound], encoding: .utf8) ?? ""
+        let bodyStart = headerEnd.upperBound
+        let bodyReceived = accumulated.distance(from: bodyStart, to: accumulated.endIndex)
+
+        switch parseContentLength(headerString) {
+        case .valid(let contentLength):
+            if contentLength > Self.maxBodyBytes {
+                send413BodyAndClose(connection: connection)
+                return
+            }
+            // Guard against clients that under-declare Content-Length and then
+            // stream more bytes — drop the connection if total exceeds either
+            // the declared length or the global cap.
+            if bodyReceived > contentLength || bodyReceived > Self.maxBodyBytes {
+                send413BodyAndClose(connection: connection)
+                return
+            }
+            if bodyReceived >= contentLength {
+                Task { await self.processRequest(connection: connection, data: accumulated) }
+            } else {
+                receiveData(connection: connection, buffer: accumulated, deadline: deadline)
+            }
+        case .missing:
+            // Reject POSTs without Content-Length; GETs never have a body.
+            let requestLine = headerString.components(separatedBy: "\r\n").first ?? ""
+            if requestLine.hasPrefix("POST ") {
+                send411AndClose(connection: connection)
+            } else {
+                Task { await self.processRequest(connection: connection, data: accumulated) }
+            }
+        case .malformed:
+            send400AndClose(connection: connection, message: "Malformed Content-Length")
+        }
+    }
+
+    private enum ContentLengthParseResult {
+        case valid(Int)
+        case missing
+        case malformed
+    }
+
+    /// Strictly parses the `Content-Length` header. Rejects negatives,
+    /// non-integer values, and trailing garbage. RFC 7230 §3.3.2 requires
+    /// a non-negative decimal — a permissive parser previously let `-1`
+    /// short-circuit the read loop.
+    private func parseContentLength(_ headers: String) -> ContentLengthParseResult {
         for line in headers.components(separatedBy: "\r\n") where line.lowercased().hasPrefix("content-length:") {
             let value = line.dropFirst("content-length:".count).trimmingCharacters(in: .whitespaces)
-            return Int(value) ?? 0
+            guard !value.isEmpty, value.allSatisfy({ $0.isASCII && $0.isNumber }), let parsed = Int(value) else {
+                return .malformed
+            }
+            return .valid(parsed)
         }
-        return 0
+        return .missing
+    }
+
+    private func send408AndClose(connection: NWConnection) {
+        sendErrorAndClose(
+            connection: connection,
+            statusCode: 408,
+            code: "REQUEST_TIMEOUT",
+            message: "Request timed out before completion"
+        )
+    }
+
+    private func send411AndClose(connection: NWConnection) {
+        sendErrorAndClose(
+            connection: connection,
+            statusCode: 411,
+            code: "LENGTH_REQUIRED",
+            message: "Content-Length header is required"
+        )
+    }
+
+    private func send413BodyAndClose(connection: NWConnection) {
+        let mb = Self.maxBodyBytes / (1024 * 1024)
+        sendErrorAndClose(
+            connection: connection,
+            statusCode: 413,
+            code: "PAYLOAD_TOO_LARGE",
+            message: "Request body exceeds \(mb) MB limit"
+        )
+    }
+
+    private func send431HeaderAndClose(connection: NWConnection) {
+        let kb = Self.maxHeaderBytes / 1024
+        sendErrorAndClose(
+            connection: connection,
+            statusCode: 431,
+            code: "REQUEST_HEADER_FIELDS_TOO_LARGE",
+            message: "Request headers exceed \(kb) KB limit"
+        )
+    }
+
+    private func send400AndClose(connection: NWConnection, message: String) {
+        sendErrorAndClose(
+            connection: connection,
+            statusCode: 400,
+            code: "BAD_REQUEST",
+            message: message
+        )
+    }
+
+    private func sendErrorAndClose(connection: NWConnection, statusCode: Int, code: String, message: String) {
+        let payload: [String: Any] = [
+            "success": false,
+            "error": ["code": code, "message": message]
+        ]
+        let body = (try? JSONSerialization.data(withJSONObject: payload)) ?? Data(#"{"success":false,"error":{"code":"INTERNAL","message":"error"}}"#.utf8)
+        let response = buildHTTPResponse(statusCode: statusCode, body: body, contentType: "application/json")
+        connection.send(content: response, completion: .contentProcessed { _ in connection.cancel() })
     }
 
     private func processRequest(connection: NWConnection, data: Data) async {
@@ -190,6 +341,10 @@ final class HTTPServer: @unchecked Sendable {
         case 200: statusText = "OK"
         case 400: statusText = "Bad Request"
         case 404: statusText = "Not Found"
+        case 408: statusText = "Request Timeout"
+        case 411: statusText = "Length Required"
+        case 413: statusText = "Payload Too Large"
+        case 431: statusText = "Request Header Fields Too Large"
         case 500: statusText = "Internal Server Error"
         default: statusText = "Unknown"
         }

--- a/apps/ios/Kelpie/Network/ServerState.swift
+++ b/apps/ios/Kelpie/Network/ServerState.swift
@@ -36,7 +36,12 @@ final class ServerState: ObservableObject {
     func startHTTPServer() {
         registerHandlers()
         router.registerFallbacks()
-        httpServer = HTTPServer(port: UInt16(deviceInfo.port), router: router)
+        do {
+            httpServer = try HTTPServer(port: UInt16(deviceInfo.port), router: router)
+        } catch {
+            print("[ServerState] Failed to construct HTTPServer: \(error)")
+            return
+        }
         httpServer?.start()
         DispatchQueue.main.async { self.isServerRunning = true }
     }

--- a/apps/macos/Kelpie/Network/HTTPServer.swift
+++ b/apps/macos/Kelpie/Network/HTTPServer.swift
@@ -17,11 +17,13 @@ enum HTTPServerError: Error, CustomStringConvertible {
 /// Uses raw NWListener since we want zero external dependencies for the server.
 final class HTTPServer: @unchecked Sendable {
     /// Maximum bytes accepted for HTTP request headers before parsing must complete.
-    /// 16 KiB matches Nginx/Apache defaults and keeps slow-loris pinning bounded.
-    static let maxHeaderBytes = 16 * 1024
-    /// Maximum request body size accepted by the server (32 MiB).
+    /// 64 KiB caps slow-loris pinning while leaving room for cookies and auth headers.
+    /// Mirrors iOS and Android.
+    static let maxHeaderBytes = 64 * 1024
+    /// Maximum request body size accepted by the server (50 MiB).
     /// Larger bodies receive `413 Payload Too Large` and the connection is closed.
-    static let maxBodyBytes = 32 * 1024 * 1024
+    /// Mirrors iOS and Android.
+    static let maxBodyBytes = 50 * 1024 * 1024
     /// Maximum lifetime of a single HTTP connection from first byte to dispatch.
     /// Prevents slow-loris clients from pinning sockets indefinitely.
     static let requestTimeoutSeconds: Double = 30
@@ -186,7 +188,7 @@ final class HTTPServer: @unchecked Sendable {
         // Enforce header byte cap before headers complete. Closing early
         // bounds slow-loris connections that drip a few bytes at a time.
         if headerSeparator == nil, accumulated.count > Self.maxHeaderBytes {
-            send413AndClose(connection: connection, message: "Request header exceeds \(Self.maxHeaderBytes) bytes")
+            send431HeaderAndClose(connection: connection)
             return
         }
 
@@ -199,7 +201,7 @@ final class HTTPServer: @unchecked Sendable {
         // Reject oversized headers even when they arrive in a single chunk —
         // the headers-complete branch above only catches drip-feed clients.
         if headerByteCount > Self.maxHeaderBytes {
-            send413AndClose(connection: connection, message: "Request header exceeds \(Self.maxHeaderBytes) bytes")
+            send431HeaderAndClose(connection: connection)
             return
         }
 
@@ -210,10 +212,14 @@ final class HTTPServer: @unchecked Sendable {
         switch parseContentLength(headerString) {
         case .valid(let contentLength):
             if contentLength > Self.maxBodyBytes {
-                send413AndClose(
-                    connection: connection,
-                    message: "Content-Length \(contentLength) exceeds limit of \(Self.maxBodyBytes) bytes"
-                )
+                send413BodyAndClose(connection: connection)
+                return
+            }
+            // Guard against clients that under-declare Content-Length and then
+            // stream more bytes — drop the connection if total exceeds either
+            // the declared length or the global cap.
+            if bodyReceived > contentLength || bodyReceived > Self.maxBodyBytes {
+                send413BodyAndClose(connection: connection)
                 return
             }
             if bodyReceived >= contentLength {
@@ -257,28 +263,59 @@ final class HTTPServer: @unchecked Sendable {
     }
 
     private func send408AndClose(connection: NWConnection) {
-        let body = Data(#"{"error":"Request timeout"}"#.utf8)
-        let response = buildHTTPResponse(statusCode: 408, body: body, contentType: "application/json")
-        connection.send(content: response, completion: .contentProcessed { _ in connection.cancel() })
+        sendErrorAndClose(
+            connection: connection,
+            statusCode: 408,
+            code: "REQUEST_TIMEOUT",
+            message: "Request timed out before completion"
+        )
     }
 
     private func send411AndClose(connection: NWConnection) {
-        let body = Data(#"{"error":"Content-Length required"}"#.utf8)
-        let response = buildHTTPResponse(statusCode: 411, body: body, contentType: "application/json")
-        connection.send(content: response, completion: .contentProcessed { _ in connection.cancel() })
+        sendErrorAndClose(
+            connection: connection,
+            statusCode: 411,
+            code: "LENGTH_REQUIRED",
+            message: "Content-Length header is required"
+        )
     }
 
-    private func send413AndClose(connection: NWConnection, message: String) {
-        let payload: [String: Any] = ["error": message]
-        let body = (try? JSONSerialization.data(withJSONObject: payload)) ?? Data(#"{"error":"Payload too large"}"#.utf8)
-        let response = buildHTTPResponse(statusCode: 413, body: body, contentType: "application/json")
-        connection.send(content: response, completion: .contentProcessed { _ in connection.cancel() })
+    private func send413BodyAndClose(connection: NWConnection) {
+        let mb = Self.maxBodyBytes / (1024 * 1024)
+        sendErrorAndClose(
+            connection: connection,
+            statusCode: 413,
+            code: "PAYLOAD_TOO_LARGE",
+            message: "Request body exceeds \(mb) MB limit"
+        )
+    }
+
+    private func send431HeaderAndClose(connection: NWConnection) {
+        let kb = Self.maxHeaderBytes / 1024
+        sendErrorAndClose(
+            connection: connection,
+            statusCode: 431,
+            code: "REQUEST_HEADER_FIELDS_TOO_LARGE",
+            message: "Request headers exceed \(kb) KB limit"
+        )
     }
 
     private func send400AndClose(connection: NWConnection, message: String) {
-        let payload: [String: Any] = ["error": message]
-        let body = (try? JSONSerialization.data(withJSONObject: payload)) ?? Data(#"{"error":"Bad request"}"#.utf8)
-        let response = buildHTTPResponse(statusCode: 400, body: body, contentType: "application/json")
+        sendErrorAndClose(
+            connection: connection,
+            statusCode: 400,
+            code: "BAD_REQUEST",
+            message: message
+        )
+    }
+
+    private func sendErrorAndClose(connection: NWConnection, statusCode: Int, code: String, message: String) {
+        let payload: [String: Any] = [
+            "success": false,
+            "error": ["code": code, "message": message],
+        ]
+        let body = (try? JSONSerialization.data(withJSONObject: payload)) ?? Data(#"{"success":false,"error":{"code":"INTERNAL","message":"error"}}"#.utf8)
+        let response = buildHTTPResponse(statusCode: statusCode, body: body, contentType: "application/json")
         connection.send(content: response, completion: .contentProcessed { _ in connection.cancel() })
     }
 
@@ -371,6 +408,7 @@ final class HTTPServer: @unchecked Sendable {
         case 408: statusText = "Request Timeout"
         case 411: statusText = "Length Required"
         case 413: statusText = "Payload Too Large"
+        case 431: statusText = "Request Header Fields Too Large"
         case 500: statusText = "Internal Server Error"
         default: statusText = "Unknown"
         }

--- a/apps/macos/Kelpie/Network/HTTPServer.swift
+++ b/apps/macos/Kelpie/Network/HTTPServer.swift
@@ -312,7 +312,7 @@ final class HTTPServer: @unchecked Sendable {
     private func sendErrorAndClose(connection: NWConnection, statusCode: Int, code: String, message: String) {
         let payload: [String: Any] = [
             "success": false,
-            "error": ["code": code, "message": message],
+            "error": ["code": code, "message": message]
         ]
         let body = (try? JSONSerialization.data(withJSONObject: payload)) ?? Data(#"{"success":false,"error":{"code":"INTERNAL","message":"error"}}"#.utf8)
         let response = buildHTTPResponse(statusCode: statusCode, body: body, contentType: "application/json")

--- a/packages/cli/tests/e2e/body-limits.e2e.test.ts
+++ b/packages/cli/tests/e2e/body-limits.e2e.test.ts
@@ -1,0 +1,100 @@
+/**
+ * E2E test verifying the native HTTP servers reject oversized requests
+ * with the standard error envelope rather than buffering them. Without
+ * these limits a single multi-GB POST OOMs the device.
+ *
+ * The tests skip silently if no device is reachable so CI doesn't fail
+ * when there is no real iOS/Android/macOS Kelpie instance available.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { testDevice, isDeviceReachable } from "./setup.js";
+
+const MAX_BODY_BYTES = 50 * 1024 * 1024;
+const MAX_HEADER_BYTES = 64 * 1024;
+
+describe("E2E: HTTP body and header size limits", () => {
+  const device = testDevice();
+  let reachable = false;
+
+  beforeAll(async () => {
+    reachable = await isDeviceReachable(device);
+  });
+
+  it("rejects bodies that exceed the 50 MB cap with 413", async () => {
+    if (!reachable) return;
+    const url = `http://${device.ip}:${device.port}/v1/navigate`;
+    // Declare a Content-Length one byte over the limit but only send a
+    // tiny body — the server must reject on declared length alone.
+    const oversizedLength = MAX_BODY_BYTES + 1;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": String(oversizedLength),
+      },
+      // Send a minimal body — the server should reject before reading.
+      body: "{}",
+    });
+    expect(res.status).toBe(413);
+    const data = (await res.json()) as { success?: boolean; error?: { code?: string } };
+    expect(data.success).toBe(false);
+    expect(data.error?.code).toBe("PAYLOAD_TOO_LARGE");
+  });
+
+  it("rejects POSTs without Content-Length with 411", async () => {
+    if (!reachable) return;
+    const url = `http://${device.ip}:${device.port}/v1/navigate`;
+    // fetch always sets Content-Length on Buffers, so we use a stream
+    // body and chunked transfer to force the missing-Content-Length path.
+    // Skip silently if the runtime can't produce a chunked POST.
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("{}"));
+        controller.close();
+      },
+    });
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: stream,
+        // @ts-expect-error — Node fetch needs duplex to send streams
+        duplex: "half",
+      });
+    } catch {
+      // Older runtimes without duplex stream support — skip.
+      return;
+    }
+    expect([411, 400]).toContain(res.status);
+    const data = (await res.json()) as { success?: boolean; error?: { code?: string } };
+    expect(data.success).toBe(false);
+  });
+
+  it("rejects header sections that exceed the 64 KB cap", async () => {
+    if (!reachable) return;
+    // Build a header value that pushes total header bytes past the cap.
+    const padding = "x".repeat(MAX_HEADER_BYTES + 1024);
+    const url = `http://${device.ip}:${device.port}/v1/navigate`;
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Padding": padding,
+        },
+        body: "{}",
+      });
+    } catch {
+      // Some runtimes refuse to send oversized headers — that is also
+      // an acceptable defence, so don't fail the test.
+      return;
+    }
+    // Either 431 (preferred) or 400 (Netty on Android may return 400
+    // depending on which decoder limit trips). Either status indicates
+    // the server refused rather than buffered the oversized header.
+    expect([400, 431]).toContain(res.status);
+  });
+});


### PR DESCRIPTION
## Summary
- Enforce 50 MB body / 64 KB header limits on iOS, Android, macOS native HTTP servers
- Reject oversized with 413 (body) / 431 (headers) using standard error envelope
- Closes round-2 audit CRITICAL #4

## Test plan
- [x] pnpm lint/build/test green
- [x] make lint-swift passes
- [x] Android gradle build passes
- [x] iOS Xcode build passes
- [x] macOS Xcode build passes