### PR TITLE
fix: encrypt LLM secrets at rest on iOS/Android/macOS

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -99,6 +99,9 @@ dependencies {
     implementation("androidx.webkit:webkit:1.10.0")
     implementation("androidx.browser:browser:1.8.0")
 
+    // Encrypted credential storage (HF token etc.)
+    implementation("androidx.security:security-crypto:1.1.0-alpha06")
+
     // HTTP Server (Ktor)
     implementation("io.ktor:ktor-server-netty:2.3.8")
     implementation("io.ktor:ktor-server-content-negotiation:2.3.8")

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
 
     <application
         android:name=".KelpieApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher"
         android:label="Kelpie"

--- a/apps/android/app/src/main/java/com/kelpie/browser/ai/AIState.kt
+++ b/apps/android/app/src/main/java/com/kelpie/browser/ai/AIState.kt
@@ -1,7 +1,7 @@
 package com.kelpie.browser.ai
 
 import android.content.Context
-import android.content.SharedPreferences
+import com.kelpie.browser.storage.SecretStore
 
 object AIState {
     const val PLATFORM_BACKEND = "platform"
@@ -9,10 +9,10 @@ object AIState {
     const val PLATFORM_MODEL_ID = "platform"
     const val DEFAULT_OLLAMA_ENDPOINT = "http://localhost:11434"
 
-    private const val PREFS_NAME = "kelpie_ai"
+    private const val LEGACY_PREFS_NAME = "kelpie_ai"
     private const val KEY_HF_TOKEN = "huggingFaceToken"
 
-    private var prefs: SharedPreferences? = null
+    private var secretStore: SecretStore? = null
 
     var isAvailable: Boolean = false
         private set
@@ -21,15 +21,38 @@ object AIState {
     var ollamaEndpoint: String? = null
 
     var huggingFaceToken: String
-        get() = prefs?.getString(KEY_HF_TOKEN, "") ?: ""
+        get() = secretStore?.get(KEY_HF_TOKEN) ?: ""
         set(value) {
-            prefs?.edit()?.putString(KEY_HF_TOKEN, value)?.apply()
+            val store = secretStore ?: return
+            if (value.isEmpty()) {
+                store.remove(KEY_HF_TOKEN)
+            } else {
+                store.set(KEY_HF_TOKEN, value)
+            }
         }
 
     fun initialize(context: Context) {
-        prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val store = SecretStore.get(context)
+        secretStore = store
+        migrateLegacyHfToken(context, store)
         isAvailable = PlatformAIEngine.isAvailable(context)
         backend = PLATFORM_BACKEND
         activeModel = null
+    }
+
+    /**
+     * Move any plaintext HF token previously stored in `SharedPreferences("kelpie_ai")`
+     * into the encrypted [SecretStore] and remove the plaintext copy.
+     */
+    private fun migrateLegacyHfToken(
+        context: Context,
+        store: SecretStore,
+    ) {
+        val legacy = context.getSharedPreferences(LEGACY_PREFS_NAME, Context.MODE_PRIVATE)
+        val plaintext = legacy.getString(KEY_HF_TOKEN, null) ?: return
+        if (plaintext.isNotEmpty() && store.get(KEY_HF_TOKEN) == null) {
+            store.set(KEY_HF_TOKEN, plaintext)
+        }
+        legacy.edit().remove(KEY_HF_TOKEN).apply()
     }
 }

--- a/apps/android/app/src/main/java/com/kelpie/browser/storage/SecretStore.kt
+++ b/apps/android/app/src/main/java/com/kelpie/browser/storage/SecretStore.kt
@@ -12,7 +12,9 @@ import androidx.security.crypto.MasterKey
  * with the master key held in the Android Keystore. The manifest disables
  * `allowBackup`, so the encrypted file cannot be exfiltrated via `adb backup`.
  */
-class SecretStore private constructor(private val prefs: SharedPreferences) {
+class SecretStore private constructor(
+    private val prefs: SharedPreferences,
+) {
     fun get(name: String): String? = prefs.getString(name, null)?.takeIf { it.isNotEmpty() }
 
     fun set(
@@ -44,7 +46,8 @@ class SecretStore private constructor(private val prefs: SharedPreferences) {
 
         private fun open(context: Context): SharedPreferences {
             val masterKey =
-                MasterKey.Builder(context.applicationContext)
+                MasterKey
+                    .Builder(context.applicationContext)
                     .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
                     .build()
             return EncryptedSharedPreferences.create(

--- a/apps/android/app/src/main/java/com/kelpie/browser/storage/SecretStore.kt
+++ b/apps/android/app/src/main/java/com/kelpie/browser/storage/SecretStore.kt
@@ -1,0 +1,59 @@
+package com.kelpie.browser.storage
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+/**
+ * Encrypted on-disk store for sensitive strings (API tokens, credentials).
+ *
+ * Backed by AndroidX `EncryptedSharedPreferences` (AES256-GCM keys, AES256-GCM values)
+ * with the master key held in the Android Keystore. The manifest disables
+ * `allowBackup`, so the encrypted file cannot be exfiltrated via `adb backup`.
+ */
+class SecretStore private constructor(private val prefs: SharedPreferences) {
+    fun get(name: String): String? = prefs.getString(name, null)?.takeIf { it.isNotEmpty() }
+
+    fun set(
+        name: String,
+        value: String,
+    ) {
+        prefs.edit().putString(name, value).apply()
+    }
+
+    fun remove(name: String) {
+        prefs.edit().remove(name).apply()
+    }
+
+    companion object {
+        private const val FILE_NAME = "kelpie_secrets"
+
+        @Volatile
+        private var instance: SecretStore? = null
+
+        fun get(context: Context): SecretStore {
+            instance?.let { return it }
+            synchronized(this) {
+                instance?.let { return it }
+                val created = SecretStore(open(context))
+                instance = created
+                return created
+            }
+        }
+
+        private fun open(context: Context): SharedPreferences {
+            val masterKey =
+                MasterKey.Builder(context.applicationContext)
+                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                    .build()
+            return EncryptedSharedPreferences.create(
+                context.applicationContext,
+                FILE_NAME,
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+            )
+        }
+    }
+}

--- a/apps/ios/Kelpie/AI/AIState.swift
+++ b/apps/ios/Kelpie/AI/AIState.swift
@@ -9,6 +9,11 @@ final class AIState: ObservableObject {
         static let backend = "ai.backend"
         static let activeModel = "ai.activeModel"
         static let ollamaEndpoint = "ai.ollamaEndpoint"
+        /// Legacy plaintext key — migrated into SecretStore on first launch then removed.
+        static let legacyHuggingFaceToken = "huggingFaceToken"
+    }
+
+    private enum SecretKey {
         static let huggingFaceToken = "huggingFaceToken"
     }
 
@@ -18,7 +23,11 @@ final class AIState: ObservableObject {
 
     @Published var huggingFaceToken: String {
         didSet {
-            UserDefaults.standard.set(huggingFaceToken, forKey: DefaultsKey.huggingFaceToken)
+            if huggingFaceToken.isEmpty {
+                SecretStore.shared.remove(SecretKey.huggingFaceToken)
+            } else {
+                SecretStore.shared.set(SecretKey.huggingFaceToken, value: huggingFaceToken)
+            }
         }
     }
 
@@ -81,7 +90,7 @@ final class AIState: ObservableObject {
         isAvailable = PlatformAIEngine.isAvailable
 
         let defaults = UserDefaults.standard
-        huggingFaceToken = defaults.string(forKey: DefaultsKey.huggingFaceToken) ?? ""
+        huggingFaceToken = Self.loadHuggingFaceTokenWithMigration(defaults: defaults)
         let storedModel = defaults.string(forKey: DefaultsKey.activeModel)
         let storedBackend = defaults.string(forKey: DefaultsKey.backend) ?? "platform"
 
@@ -109,5 +118,21 @@ final class AIState: ObservableObject {
         backend = "ollama"
         activeModel = model
         ollamaEndpoint = endpoint
+    }
+
+    /// Migrates any plaintext HF token previously stored in `UserDefaults`
+    /// into `SecretStore` and deletes the plaintext copy.
+    private static func loadHuggingFaceTokenWithMigration(defaults: UserDefaults) -> String {
+        let store = SecretStore.shared
+        if let legacy = defaults.string(forKey: DefaultsKey.legacyHuggingFaceToken) {
+            defaults.removeObject(forKey: DefaultsKey.legacyHuggingFaceToken)
+            if !legacy.isEmpty {
+                if store.get(SecretKey.huggingFaceToken) == nil {
+                    store.set(SecretKey.huggingFaceToken, value: legacy)
+                }
+                return legacy
+            }
+        }
+        return store.get(SecretKey.huggingFaceToken) ?? ""
     }
 }

--- a/apps/ios/Project.swift
+++ b/apps/ios/Project.swift
@@ -25,6 +25,7 @@ let kelpieApp = Target.target(
         .glob("Kelpie/**/*.swift"),
         // Shared from macOS — cross-project source references
         .glob("../macos/Kelpie/Handlers/Snapshot3DBridge.swift"),
+        .glob("../macos/Kelpie/Storage/SecretStore.swift"),
     ],
     resources: [
         .glob(pattern: "Kelpie/Assets.xcassets"),

--- a/apps/macos/Kelpie/AI/AIState.swift
+++ b/apps/macos/Kelpie/AI/AIState.swift
@@ -73,8 +73,23 @@ final class AIState: ObservableObject {
     @Published private(set) var nativeModelCards: [AINativeModelCard] = []
     @Published private(set) var ollamaModels: [AIOllamaModel] = []
     @Published private(set) var lastError: String?
-    @AppStorage("huggingFaceToken") var huggingFaceToken: String = ""
+    @Published var huggingFaceToken: String {
+        didSet {
+            if huggingFaceToken.isEmpty {
+                SecretStore.shared.remove(SecretKey.huggingFaceToken)
+            } else {
+                SecretStore.shared.set(SecretKey.huggingFaceToken, value: huggingFaceToken)
+            }
+        }
+    }
     var onAuthFailureNavigate: ((URL) -> Void)?
+
+    private enum SecretKey {
+        static let huggingFaceToken = "huggingFaceToken"
+    }
+
+    /// Legacy plaintext UserDefaults key — migrated on first launch then removed.
+    private static let legacyHuggingFaceTokenKey = "huggingFaceToken"
 
     private var serverPort: UInt16?
     private var refreshTask: Task<Void, Never>?
@@ -94,10 +109,29 @@ final class AIState: ObservableObject {
         isAppleSilicon = isArm64
         deviceCapabilities = Self.currentDeviceCapabilities()
         isAvailable = isArm64
+        huggingFaceToken = Self.loadHuggingFaceTokenWithMigration()
         rebuildModelCards()
         refreshTask = Task { [weak self] in
             await self?.refreshLoop()
         }
+    }
+
+    /// Migrates any plaintext HF token previously stored in `UserDefaults`
+    /// (legacy `@AppStorage("huggingFaceToken")`) into `SecretStore` and
+    /// deletes the plaintext copy.
+    private static func loadHuggingFaceTokenWithMigration() -> String {
+        let defaults = UserDefaults.standard
+        let store = SecretStore.shared
+        if let legacy = defaults.string(forKey: legacyHuggingFaceTokenKey) {
+            defaults.removeObject(forKey: legacyHuggingFaceTokenKey)
+            if !legacy.isEmpty {
+                if store.get(SecretKey.huggingFaceToken) == nil {
+                    store.set(SecretKey.huggingFaceToken, value: legacy)
+                }
+                return legacy
+            }
+        }
+        return store.get(SecretKey.huggingFaceToken) ?? ""
     }
 
     func configure(localServerPort: UInt16) {

--- a/apps/macos/Kelpie/Storage/SecretStore.swift
+++ b/apps/macos/Kelpie/Storage/SecretStore.swift
@@ -1,0 +1,142 @@
+import CryptoKit
+import Foundation
+
+/// Encrypted on-disk store for sensitive strings (API tokens, credentials).
+///
+/// Storage format:
+/// - Ciphertext file at `<AppSupport>/Kelpie/secrets.enc` containing AES-GCM
+///   sealed bytes whose plaintext is a JSON `[String: String]` dictionary.
+/// - Symmetric key (32 random bytes) base64-encoded in `UserDefaults` under
+///   `SecretStore.keyDefaultsKey`. The key alone or the ciphertext alone
+///   is useless — both are required to recover any secret.
+///
+/// macOS Keychain is explicitly forbidden by AGENTS.md, so this class uses
+/// file storage for both iOS and macOS. The file is created with
+/// `NSFileProtectionComplete` (iOS) and chmod 0600 (macOS) to prevent
+/// plaintext exfiltration via app backups or shared sandbox snapshots.
+final class SecretStore {
+    static let shared = SecretStore()
+
+    private enum Const {
+        static let keyDefaultsKey = "secretstore.key.v1"
+        static let directoryName = "Kelpie"
+        static let fileName = "secrets.enc"
+    }
+
+    private let fileURL: URL
+    private let key: SymmetricKey
+    private let queue = DispatchQueue(label: "com.kelpie.secretstore", qos: .userInitiated)
+    private var cache: [String: String]
+
+    private init() {
+        fileURL = Self.resolveFileURL()
+        key = Self.loadOrCreateKey()
+        cache = Self.loadCache(from: fileURL, key: key)
+    }
+
+    func get(_ name: String) -> String? {
+        queue.sync { cache[name] }
+    }
+
+    func set(_ name: String, value: String) {
+        queue.sync {
+            cache[name] = value
+            persistLocked()
+        }
+    }
+
+    func remove(_ name: String) {
+        queue.sync {
+            cache.removeValue(forKey: name)
+            persistLocked()
+        }
+    }
+
+    // MARK: - Persistence
+
+    private func persistLocked() {
+        do {
+            let json = try JSONSerialization.data(withJSONObject: cache, options: [.sortedKeys])
+            let sealed = try AES.GCM.seal(json, using: key)
+            guard let combined = sealed.combined else {
+                NSLog("SecretStore: failed to combine sealed box")
+                return
+            }
+            try ensureDirectoryExists()
+            try combined.write(to: fileURL, options: [.atomic, .completeFileProtection])
+            applyFilePermissions()
+        } catch {
+            NSLog("SecretStore: persist failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func ensureDirectoryExists() throws {
+        let directory = fileURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    private func applyFilePermissions() {
+        #if os(macOS)
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o600))],
+            ofItemAtPath: fileURL.path
+        )
+        #endif
+    }
+
+    // MARK: - Setup
+
+    private static func resolveFileURL() -> URL {
+        let fileManager = FileManager.default
+        let base: URL
+        if let appSupport = try? fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        ) {
+            base = appSupport
+        } else {
+            base = fileManager.temporaryDirectory
+        }
+        return base
+            .appendingPathComponent(Const.directoryName, isDirectory: true)
+            .appendingPathComponent(Const.fileName, isDirectory: false)
+    }
+
+    private static func loadOrCreateKey() -> SymmetricKey {
+        let defaults = UserDefaults.standard
+        if let encoded = defaults.string(forKey: Const.keyDefaultsKey),
+           let raw = Data(base64Encoded: encoded), raw.count == 32 {
+            return SymmetricKey(data: raw)
+        }
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        let data: Data
+        if status == errSecSuccess {
+            data = Data(bytes)
+        } else {
+            // Fallback — should never trigger on Apple platforms, but never crash a launch.
+            data = SymmetricKey(size: .bits256).withUnsafeBytes { Data($0) }
+        }
+        defaults.set(data.base64EncodedString(), forKey: Const.keyDefaultsKey)
+        return SymmetricKey(data: data)
+    }
+
+    private static func loadCache(from url: URL, key: SymmetricKey) -> [String: String] {
+        guard FileManager.default.fileExists(atPath: url.path) else { return [:] }
+        do {
+            let blob = try Data(contentsOf: url)
+            let sealed = try AES.GCM.SealedBox(combined: blob)
+            let plaintext = try AES.GCM.open(sealed, using: key)
+            guard let decoded = try JSONSerialization.jsonObject(with: plaintext) as? [String: String] else {
+                NSLog("SecretStore: ciphertext decoded to unexpected shape — discarding")
+                return [:]
+            }
+            return decoded
+        } catch {
+            NSLog("SecretStore: load failed (\(error.localizedDescription)) — starting empty")
+            return [:]
+        }
+    }
+}

--- a/apps/macos/Kelpie/Views/SettingsView.swift
+++ b/apps/macos/Kelpie/Views/SettingsView.swift
@@ -7,10 +7,11 @@ struct SettingsView: View {
     @ObservedObject var rendererState: RendererState
     var onNavigate: ((String) -> Void)?
     @ObservedObject private var aiState = AIState.shared
-    @AppStorage("huggingFaceToken") private var huggingFaceToken: String = ""
     @Environment(\.dismiss) private var dismiss
     @State private var showHFTokenField = false
     @State private var hfTokenDraft = ""
+
+    private var huggingFaceToken: String { aiState.huggingFaceToken }
 
     var body: some View {
         VStack {
@@ -94,7 +95,7 @@ struct SettingsView: View {
                         HStack {
                             if !huggingFaceToken.isEmpty {
                                 Button("Clear") {
-                                    huggingFaceToken = ""
+                                    aiState.huggingFaceToken = ""
                                     hfTokenDraft = ""
                                     showHFTokenField = false
                                 }
@@ -107,7 +108,7 @@ struct SettingsView: View {
                             }
                             .controlSize(.small)
                             Button("Save") {
-                                huggingFaceToken = hfTokenDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+                                aiState.huggingFaceToken = hfTokenDraft.trimmingCharacters(in: .whitespacesAndNewlines)
                                 hfTokenDraft = ""
                                 showHFTokenField = false
                             }


### PR DESCRIPTION
## Summary
- iOS+macOS: route HuggingFace token through SecretStore (AES-GCM encrypted file, no Keychain)
- Android: EncryptedSharedPreferences + disable adb backup
- Migrate-and-delete strategy on first launch
- Closes round-2 audit CRITICAL #3 (plaintext secrets at rest)

## Test plan
- [x] pnpm lint/build/test
- [x] make lint-swift
- [x] Android gradle build
- [x] iOS + macOS Xcode build