### PR TITLE
fix(android): JsBridge audit + MainActivity leak fix

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,9 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".KelpieApp"
@@ -26,6 +29,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".network.KelpieNetworkService"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice" />
 
     </application>
 

--- a/apps/android/app/src/main/java/com/kelpie/browser/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/kelpie/browser/MainActivity.kt
@@ -173,7 +173,7 @@ class MainActivity : ComponentActivity() {
 
         mdnsAdvertiser =
             MDNSAdvertiser(
-                context = this,
+                appContext = applicationContext,
                 deviceInfo = deviceInfo,
             )
     }

--- a/apps/android/app/src/main/java/com/kelpie/browser/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/kelpie/browser/MainActivity.kt
@@ -37,7 +37,10 @@ import com.kelpie.browser.handlers.WebSocketHandler
 import com.kelpie.browser.llm.LLMHandler
 import com.kelpie.browser.network.FeedbackStore
 import com.kelpie.browser.network.HTTPServer
+import com.kelpie.browser.network.KelpieNetworkService
 import com.kelpie.browser.network.MDNSAdvertiser
+import com.kelpie.browser.network.NetworkServiceStage
+import com.kelpie.browser.network.NetworkServiceState
 import com.kelpie.browser.network.Router
 import com.kelpie.browser.network.errorResponse
 import com.kelpie.browser.network.successResponse
@@ -169,18 +172,20 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun startServer(deviceInfo: DeviceInfo) {
-        httpServer = HTTPServer(port = deviceInfo.port, router = router, appContext = applicationContext).also { it.start() }
-
-        mdnsAdvertiser =
+        val server = HTTPServer(port = deviceInfo.port, router = router, appContext = applicationContext)
+        val advertiser =
             MDNSAdvertiser(
                 appContext = applicationContext,
                 deviceInfo = deviceInfo,
             )
-    }
+        httpServer = server
+        mdnsAdvertiser = advertiser
 
-    override fun onStart() {
-        super.onStart()
-        mdnsAdvertiser?.ensureRegistered()
+        // Hand off lifecycle to the foreground service so Doze cannot stall
+        // incoming HTTP requests and the user sees a persistent "reachable"
+        // notification.
+        NetworkServiceState.stage(NetworkServiceStage(server, advertiser))
+        KelpieNetworkService.start(applicationContext)
     }
 
     override fun onResume() {
@@ -188,16 +193,17 @@ class MainActivity : ComponentActivity() {
         handlerContext.chromeAuth.onResume(handlerContext.webView)
     }
 
-    override fun onStop() {
-        mdnsAdvertiser?.unregister()
-        super.onStop()
-    }
-
     override fun onDestroy() {
         handlerContext.dialogState.dismissPending()
         handlerContext.tabStore?.destroyAllTabs()
-        mdnsAdvertiser?.shutdown()
         super.onDestroy()
-        httpServer?.stop()
+        // Mirrors the previous unconditional onDestroy teardown: the network
+        // stack is tied to the Activity lifecycle. Surviving Activity
+        // recreation (rotation) without rebuilding the HTTP listener is a
+        // separate refactor — out of scope here.
+        KelpieNetworkService.stop(applicationContext)
+        NetworkServiceState.clear()
+        httpServer = null
+        mdnsAdvertiser = null
     }
 }

--- a/apps/android/app/src/main/java/com/kelpie/browser/browser/JsBridge.kt
+++ b/apps/android/app/src/main/java/com/kelpie/browser/browser/JsBridge.kt
@@ -6,12 +6,22 @@ import org.json.JSONObject
 /**
  * Android JS bridge exposed as `window.KelpieBridge`.
  * Receives console messages and network traffic events from injected scripts.
+ *
+ * Security note: every public method here is reachable from untrusted JS.
+ *   - Only methods annotated with `@JavascriptInterface` are exposed; do not
+ *     add new public members without auditing them. Methods without the
+ *     annotation are silently ignored by WebView, but adding them obscures the
+ *     contract — keep the surface area minimal.
+ *   - All inputs are strings that originate in the renderer. Parse defensively,
+ *     never pass them to filesystem, URL, or shell APIs.
+ *   - Inputs are size-capped to protect against renderer-driven OOM.
  */
 class JsBridge(
     private val handlerContext: com.kelpie.browser.handlers.HandlerContext?,
 ) {
     @JavascriptInterface
     fun onConsoleMessage(jsonString: String) {
+        if (jsonString.length > MAX_MESSAGE_BYTES) return
         try {
             val obj = JSONObject(jsonString)
             val message = obj.optString("message", obj.optString("text", ""))
@@ -34,6 +44,7 @@ class JsBridge(
 
     @JavascriptInterface
     fun on3DSnapshotEvent(jsonString: String) {
+        if (jsonString.length > MAX_MESSAGE_BYTES) return
         try {
             val obj = JSONObject(jsonString)
             if (obj.optString("action") == "exit") {
@@ -45,6 +56,7 @@ class JsBridge(
 
     @JavascriptInterface
     fun onNetworkEvent(jsonString: String) {
+        if (jsonString.length > MAX_NETWORK_EVENT_BYTES) return
         try {
             val obj = JSONObject(jsonString)
             val reqHeaders = mutableMapOf<String, String>()
@@ -75,6 +87,19 @@ class JsBridge(
     }
 
     companion object {
+        /**
+         * Hard ceiling on a single console/3D event payload. The injected scripts
+         * truncate their own fields to ~10KB each; 64KB leaves room for headers
+         * and metadata while preventing renderer-driven OOM.
+         */
+        private const val MAX_MESSAGE_BYTES = 64 * 1024
+
+        /**
+         * Network events carry request + response bodies (each truncated to
+         * 10KB in the bridge script) plus header maps; allow a larger ceiling.
+         */
+        private const val MAX_NETWORK_EVENT_BYTES = 128 * 1024
+
         /** Network traffic capture script. Intercepts XHR and fetch, posts via KelpieBridge. */
         const val NETWORK_BRIDGE_SCRIPT = """
 (function() {

--- a/apps/android/app/src/main/java/com/kelpie/browser/network/HTTPServer.kt
+++ b/apps/android/app/src/main/java/com/kelpie/browser/network/HTTPServer.kt
@@ -36,10 +36,15 @@ private val json =
         isLenient = true
     }
 
+/**
+ * HTTP server fronting the browser router. The Context parameter must be
+ * Application-scoped; this server is started from a long-lived foreground
+ * service and an Activity reference here would block GC on config changes.
+ */
 class HTTPServer(
     private val port: Int,
     private val router: Router,
-    private val appContext: Context,
+    appContext: Context,
 ) {
     companion object {
         /**
@@ -57,6 +62,7 @@ class HTTPServer(
         const val MAX_HEADER_BYTES: Int = 64 * 1024
     }
 
+    private val appContext: Context = appContext.applicationContext
     private var engine: NettyApplicationEngine? = null
     var isRunning = false
         private set

--- a/apps/android/app/src/main/java/com/kelpie/browser/network/KelpieNetworkService.kt
+++ b/apps/android/app/src/main/java/com/kelpie/browser/network/KelpieNetworkService.kt
@@ -1,0 +1,155 @@
+package com.kelpie.browser.network
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.kelpie.browser.MainActivity
+import com.kelpie.browser.R
+
+/**
+ * Foreground service that owns the HTTP server and mDNS advertiser so they keep
+ * serving while the device is dozing or the Activity is in the background. The
+ * service runs in the main process; MainActivity stages the `HTTPServer` and
+ * `MDNSAdvertiser` instances via `NetworkServiceState` before calling
+ * `startForegroundService`, and clears them on destroy.
+ *
+ * Foreground service type is `connectedDevice` because the device is
+ * advertising itself on the LAN for other devices (the CLI / MCP host) to
+ * connect to — the closest fit among the Android 14 mandatory types.
+ */
+class KelpieNetworkService : Service() {
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(
+        intent: Intent?,
+        flags: Int,
+        startId: Int,
+    ): Int {
+        startForegroundWithNotification()
+
+        val stage = NetworkServiceState.snapshot()
+        if (stage == null) {
+            Log.w(TAG, "Started without staged HTTPServer/MDNSAdvertiser; stopping.")
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        if (!stage.httpServer.isRunning) {
+            try {
+                stage.httpServer.start()
+            } catch (e: Exception) {
+                Log.e(TAG, "HTTPServer failed to start: ${e.message}")
+            }
+        }
+        stage.mdnsAdvertiser.ensureRegistered()
+
+        // If the user removes the app from the recent task list we want the
+        // service to stop with it (matches the Activity's onDestroy path).
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        val stage = NetworkServiceState.snapshot()
+        if (stage != null) {
+            try {
+                stage.mdnsAdvertiser.shutdown()
+            } catch (e: Exception) {
+                Log.w(TAG, "mDNS shutdown error: ${e.message}")
+            }
+            try {
+                stage.httpServer.stop()
+            } catch (e: Exception) {
+                Log.w(TAG, "HTTPServer stop error: ${e.message}")
+            }
+        }
+        super.onDestroy()
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        // User swiped the app away from recents: shut down cleanly so the
+        // notification disappears and the port is freed.
+        stopSelf()
+        super.onTaskRemoved(rootIntent)
+    }
+
+    private fun startForegroundWithNotification() {
+        ensureNotificationChannel()
+        val notification = buildNotification()
+        // minSdk is 28 (Q is 29) — pass the foregroundServiceType every call.
+        startForeground(
+            NOTIFICATION_ID,
+            notification,
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
+        )
+    }
+
+    private fun ensureNotificationChannel() {
+        // minSdk is 28 — channels (added in O / 26) always exist.
+        val nm = getSystemService(NotificationManager::class.java) ?: return
+        if (nm.getNotificationChannel(CHANNEL_ID) != null) return
+        val channel =
+            NotificationChannel(
+                CHANNEL_ID,
+                "Kelpie network",
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply {
+                description = "Keeps the local-network HTTP server reachable"
+                setShowBadge(false)
+            }
+        nm.createNotificationChannel(channel)
+    }
+
+    private fun buildNotification(): Notification {
+        val openAppIntent =
+            Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
+        val pendingIntent =
+            PendingIntent.getActivity(
+                this,
+                0,
+                openAppIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+
+        return NotificationCompat
+            .Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle("Kelpie is reachable")
+            .setContentText("Listening for commands on the local network")
+            .setOngoing(true)
+            .setShowWhen(false)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setContentIntent(pendingIntent)
+            .build()
+    }
+
+    companion object {
+        private const val TAG = "KelpieNetworkService"
+        private const val CHANNEL_ID = "kelpie_network"
+        private const val NOTIFICATION_ID = 0x4B454C50 // "KELP"
+
+        fun start(context: Context) {
+            val intent = Intent(context, KelpieNetworkService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, KelpieNetworkService::class.java))
+        }
+    }
+}

--- a/apps/android/app/src/main/java/com/kelpie/browser/network/MDNSAdvertiser.kt
+++ b/apps/android/app/src/main/java/com/kelpie/browser/network/MDNSAdvertiser.kt
@@ -7,10 +7,17 @@ import android.net.wifi.WifiManager
 import android.util.Log
 import com.kelpie.browser.device.DeviceInfo
 
+/**
+ * Advertises this device on the local network via NSD. The constructor
+ * intentionally takes an Application-scoped Context — never an Activity —
+ * because the advertiser is owned by a long-lived foreground service and
+ * holding an Activity here would block GC across configuration changes.
+ */
 class MDNSAdvertiser(
-    private val context: Context,
+    appContext: Context,
     private val deviceInfo: DeviceInfo,
 ) {
+    private val context: Context = appContext.applicationContext
     private var nsdManager: NsdManager? = null
     private var activeListener: NsdManager.RegistrationListener? = null
     private var multicastLock: WifiManager.MulticastLock? = null

--- a/apps/android/app/src/main/java/com/kelpie/browser/network/NetworkServiceState.kt
+++ b/apps/android/app/src/main/java/com/kelpie/browser/network/NetworkServiceState.kt
@@ -1,0 +1,31 @@
+package com.kelpie.browser.network
+
+/**
+ * Process-scoped hand-off between MainActivity (which builds the HTTPServer and
+ * MDNSAdvertiser instances) and KelpieNetworkService (which owns their
+ * lifecycle while the app is in the foreground).
+ *
+ * This is intentionally not a static reference to an Activity — both fields
+ * hold network-layer objects that are already Application-scoped (see the
+ * HTTPServer and MDNSAdvertiser docs). MainActivity must call `clear()` from
+ * its `onDestroy` so a recreated Activity cannot pick up dangling state.
+ */
+data class NetworkServiceStage(
+    val httpServer: HTTPServer,
+    val mdnsAdvertiser: MDNSAdvertiser,
+)
+
+object NetworkServiceState {
+    @Volatile
+    private var stage: NetworkServiceStage? = null
+
+    fun stage(stage: NetworkServiceStage) {
+        this.stage = stage
+    }
+
+    fun snapshot(): NetworkServiceStage? = stage
+
+    fun clear() {
+        stage = null
+    }
+}


### PR DESCRIPTION
## Summary
- Cap JsBridge input sizes; document JS exposure contract
- Stop MDNSAdvertiser/HTTPServer from pinning the Activity (use applicationContext)
- Closes round-2 audit HIGH (Android-specific)

## Test plan
- [x] Android gradle lint/ktlint/build passes