### PR TITLE
fix(cli): JSON-RPC envelope validation; registry TTL; surface per-device errors in group orchestrator

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -940,6 +940,35 @@ kelpie group navigate "https://example.com" --include "a1b2c3d4,My iPhone" # onl
 
 `--include` accepts a comma-separated list of device IDs or names. When both `--include` and `--platform` are specified, only devices matching both filters are targeted.
 
+### Per-device failures and exit codes
+
+Every group command runs against the filtered set of devices in parallel and returns a structured result:
+
+```json
+{
+  "command": "navigate",
+  "deviceCount": 3,
+  "succeeded": 2,
+  "failed": 1,
+  "results": [
+    { "device": {"name": "iPhone", "platform": "ios", "resolution": "390x844"}, "success": true,  "data": {"success": true} },
+    { "device": {"name": "Pixel",  "platform": "android", "resolution": "412x915"}, "success": false, "error": {"code": "NAVIGATION_ERROR", "message": "DNS failed"} },
+    { "device": {"name": "iPad",   "platform": "ios", "resolution": "1024x1366"}, "success": true,  "data": {"success": true} }
+  ]
+}
+```
+
+- Per-device failures appear in `results[]` as entries with `success: false` and a populated `error` envelope. They are **never** silently dropped.
+- By default, the CLI exits with status code `1` if **any** device fails — even when the rest succeeded. Use this for scripts that must treat any device failure as fatal.
+- Pass `--allow-partial` to suppress the non-zero exit and treat the run as successful as long as the orchestrator itself completed. The output payload is identical with or without the flag.
+
+```bash
+kelpie group navigate "https://example.com"                   # exit 1 if any device fails
+kelpie group navigate "https://example.com" --allow-partial   # exit 0 even if some devices fail
+```
+
+For smart queries (`find-button`, `find-element`, `find-link`, `find-input`), only **device-level errors** (transport/protocol failures) flip the exit code. A genuine "element absent" result is reported in `notFound[]` but does not set a non-zero exit, because it is the expected answer when the element is not present on that page.
+
 ---
 
 ## MCP Server

--- a/packages/cli/src/commands/group.ts
+++ b/packages/cli/src/commands/group.ts
@@ -3,20 +3,53 @@ import { dirname, join, resolve } from "node:path";
 import type { Command } from "commander";
 import { getAllDevices } from "../discovery/registry.js";
 import { sendCommand } from "../client/http-client.js";
-import { executeGroup, executeSmartQuery } from "../group/orchestrator.js";
+import {
+  executeGroup,
+  executeSmartQuery,
+  type GroupResult,
+  type SmartQueryResult,
+} from "../group/orchestrator.js";
 import { filterDevices, type FilterOptions } from "../group/filter.js";
 import { getGlobals } from "./helpers.js";
 import { print } from "../output/formatter.js";
+
+interface GroupCommandOptions extends FilterOptions {
+  allowPartial?: boolean;
+}
 
 function addGroupOptions(cmd: Command): Command {
   return cmd
     .option("--platform <platform>", "Filter: ios or android")
     .option("--include <devices>", "Only these devices (comma-separated IDs or names)")
-    .option("--exclude <devices>", "Exclude these devices (comma-separated)");
+    .option("--exclude <devices>", "Exclude these devices (comma-separated)")
+    .option(
+      "--allow-partial",
+      "Exit 0 even when some devices fail (default: exit non-zero if any device fails)",
+    );
 }
 
 function getFilteredDevices(opts: FilterOptions): ReturnType<typeof getAllDevices> {
   return filterDevices(getAllDevices(), opts);
+}
+
+/** Set exit code 1 if any device failed and --allow-partial was not passed. */
+function applyExitCode(failed: number, opts: GroupCommandOptions): void {
+  if (failed > 0 && !opts.allowPartial) {
+    process.exitCode = 1;
+  }
+}
+
+function printGroupResult<T>(result: GroupResult<T>, opts: GroupCommandOptions, format: "json" | "table" | "text"): void {
+  print(result, format);
+  applyExitCode(result.failed, opts);
+}
+
+function printSmartQueryResult<T>(result: SmartQueryResult<T>, opts: GroupCommandOptions, format: "json" | "table" | "text"): void {
+  print(result, format);
+  // For smart queries, "not found because of an error" counts as a failure.
+  // notFound entries with no error reason are simply "element absent" and do
+  // not flip exit code — only device-level errors do.
+  applyExitCode(result.errors.length, opts);
 }
 
 export function registerGroup(program: Command): void {
@@ -29,12 +62,11 @@ export function registerGroup(program: Command): void {
     group
       .command("navigate <url>")
       .description("Navigate all devices to a URL"),
-  ).action(async (url: string, opts: FilterOptions) => {
+  ).action(async (url: string, opts: GroupCommandOptions) => {
     const globals = getGlobals(program);
     const devices = getFilteredDevices(opts);
     const result = await executeGroup(devices, "navigate", { url }, globals.timeout);
-    print(result, globals.format);
-    if (result.failed > 0) process.exitCode = 1;
+    printGroupResult(result, opts, globals.format);
   });
 
   // Screenshot
@@ -43,7 +75,7 @@ export function registerGroup(program: Command): void {
       .command("screenshot")
       .description("Screenshot all devices")
       .option("--output <dir>", "Save directory"),
-  ).action(async (opts: FilterOptions & { output?: string }) => {
+  ).action(async (opts: GroupCommandOptions & { output?: string }) => {
     const globals = getGlobals(program);
     const devices = getFilteredDevices(opts);
     const results = await Promise.all(
@@ -65,6 +97,8 @@ export function registerGroup(program: Command): void {
       }),
     );
     print({ command: "screenshot", results }, globals.format);
+    const failed = results.filter((r) => !r.success).length;
+    applyExitCode(failed, opts);
   });
 
   // Fill
@@ -72,12 +106,11 @@ export function registerGroup(program: Command): void {
     group
       .command("fill <selector> <value>")
       .description("Fill a field on all devices"),
-  ).action(async (selector: string, value: string, opts: FilterOptions) => {
+  ).action(async (selector: string, value: string, opts: GroupCommandOptions) => {
     const globals = getGlobals(program);
     const devices = getFilteredDevices(opts);
     const result = await executeGroup(devices, "fill", { selector, value }, globals.timeout);
-    print(result, globals.format);
-    if (result.failed > 0) process.exitCode = 1;
+    printGroupResult(result, opts, globals.format);
   });
 
   // Click
@@ -85,12 +118,11 @@ export function registerGroup(program: Command): void {
     group
       .command("click <selector>")
       .description("Click an element on all devices"),
-  ).action(async (selector: string, opts: FilterOptions) => {
+  ).action(async (selector: string, opts: GroupCommandOptions) => {
     const globals = getGlobals(program);
     const devices = getFilteredDevices(opts);
     const result = await executeGroup(devices, "click", { selector }, globals.timeout);
-    print(result, globals.format);
-    if (result.failed > 0) process.exitCode = 1;
+    printGroupResult(result, opts, globals.format);
   });
 
   // Scroll2
@@ -98,12 +130,11 @@ export function registerGroup(program: Command): void {
     group
       .command("scroll2 <selector>")
       .description("Resolution-aware scroll on all devices"),
-  ).action(async (selector: string, opts: FilterOptions) => {
+  ).action(async (selector: string, opts: GroupCommandOptions) => {
     const globals = getGlobals(program);
     const devices = getFilteredDevices(opts);
     const result = await executeGroup(devices, "scroll2", { selector, position: "center" }, globals.timeout);
-    print(result, globals.format);
-    if (result.failed > 0) process.exitCode = 1;
+    printGroupResult(result, opts, globals.format);
   });
 
   // Smart queries
@@ -117,11 +148,11 @@ export function registerGroup(program: Command): void {
       group
         .command(`${cmd} <${argName}>`)
         .description(`Find ${cmd.replace("find-", "")} across all devices`),
-    ).action(async (arg: string, opts: FilterOptions) => {
+    ).action(async (arg: string, opts: GroupCommandOptions) => {
       const globals = getGlobals(program);
       const devices = getFilteredDevices(opts);
       const result = await executeSmartQuery(devices, method, { [argName]: arg }, globals.timeout);
-      print(result, globals.format);
+      printSmartQueryResult(result, opts, globals.format);
     });
   }
 
@@ -138,12 +169,11 @@ export function registerGroup(program: Command): void {
       group
         .command(cmd)
         .description(`Get ${cmd} from all devices`),
-    ).action(async (opts: FilterOptions) => {
+    ).action(async (opts: GroupCommandOptions) => {
       const globals = getGlobals(program);
       const devices = getFilteredDevices(opts);
       const result = await executeGroup(devices, method, {}, globals.timeout);
-      print(result, globals.format);
-      if (result.failed > 0) process.exitCode = 1;
+      printGroupResult(result, opts, globals.format);
     });
   }
 
@@ -152,12 +182,11 @@ export function registerGroup(program: Command): void {
     group
       .command("eval <expression>")
       .description("Evaluate JS on all devices"),
-  ).action(async (expression: string, opts: FilterOptions) => {
+  ).action(async (expression: string, opts: GroupCommandOptions) => {
     const globals = getGlobals(program);
     const devices = getFilteredDevices(opts);
     const result = await executeGroup(devices, "evaluate", { expression }, globals.timeout);
-    print(result, globals.format);
-    if (result.failed > 0) process.exitCode = 1;
+    printGroupResult(result, opts, globals.format);
   });
 
   // Keyboard show/hide
@@ -165,21 +194,21 @@ export function registerGroup(program: Command): void {
     group
       .command("keyboard-show")
       .description("Show keyboard on all devices"),
-  ).action(async (opts: FilterOptions) => {
+  ).action(async (opts: GroupCommandOptions) => {
     const globals = getGlobals(program);
     const devices = getFilteredDevices(opts);
     const result = await executeGroup(devices, "showKeyboard", {}, globals.timeout);
-    print(result, globals.format);
+    printGroupResult(result, opts, globals.format);
   });
 
   addGroupOptions(
     group
       .command("keyboard-hide")
       .description("Hide keyboard on all devices"),
-  ).action(async (opts: FilterOptions) => {
+  ).action(async (opts: GroupCommandOptions) => {
     const globals = getGlobals(program);
     const devices = getFilteredDevices(opts);
     const result = await executeGroup(devices, "hideKeyboard", {}, globals.timeout);
-    print(result, globals.format);
+    printGroupResult(result, opts, globals.format);
   });
 }

--- a/packages/cli/src/discovery/registry.ts
+++ b/packages/cli/src/discovery/registry.ts
@@ -5,6 +5,33 @@ import { loadBrowserStore } from "../browser/store.js";
 const devices = new Map<string, DiscoveredDevice>();
 let autoScanned = false;
 
+/**
+ * Devices that go offline rarely send mDNS goodbye packets. Without a TTL,
+ * stale entries linger in the registry forever and the CLI happily routes
+ * commands to dead targets. Evict entries whose lastSeen is older than this
+ * threshold on every read.
+ *
+ * 90s matches the upper bound used by typical mDNS announcement intervals
+ * (most stacks re-announce every 60-75s); a missing announcement for over
+ * 90s is a strong signal the device is gone.
+ */
+const MDNS_TTL_MS = 90_000;
+
+/** Exposed for tests: time-to-live for unrefreshed device entries (ms). */
+export const TTL_MS = MDNS_TTL_MS;
+
+function isExpired(device: DiscoveredDevice, now: number): boolean {
+  return now - device.lastSeen > MDNS_TTL_MS;
+}
+
+function evictExpired(now: number = Date.now()): void {
+  for (const [id, device] of devices) {
+    if (isExpired(device, now)) {
+      devices.delete(id);
+    }
+  }
+}
+
 export function addDevice(device: DiscoveredDevice): void {
   devices.set(device.id, device);
 }
@@ -18,10 +45,12 @@ export function removeDevice(id: string): void {
 }
 
 export function getAllDevices(): DiscoveredDevice[] {
+  evictExpired();
   return Array.from(devices.values());
 }
 
 export async function getDevice(query: string): Promise<DiscoveredDevice | undefined> {
+  evictExpired();
   // Auto-scan on first use so --device works without a prior `discover` call
   if (!autoScanned && devices.size === 0) {
     autoScanned = true;
@@ -102,5 +131,6 @@ export function clearDevices(): void {
 }
 
 export function deviceCount(): number {
+  evictExpired();
   return devices.size;
 }

--- a/packages/cli/src/group/orchestrator.ts
+++ b/packages/cli/src/group/orchestrator.ts
@@ -27,6 +27,12 @@ export interface SmartQueryResult<T = unknown> {
   deviceCount: number;
   found: ({ device: DeviceMeta } & T)[];
   notFound: { device: DeviceMeta; reason: string }[];
+  /**
+   * Devices whose request errored at the transport/protocol level (not just
+   * "element absent"). Surfacing these separately lets the CLI flip exit code
+   * on real failures without treating an empty page as an error.
+   */
+  errors: { device: DeviceMeta; error: { code: string; message: string } }[];
 }
 
 function extractError(data: unknown): { code: string; message: string } | undefined {
@@ -106,17 +112,20 @@ export async function executeSmartQuery<T extends Record<string, unknown>>(
 
   const found: ({ device: DeviceMeta } & T)[] = [];
   const notFound: { device: DeviceMeta; reason: string }[] = [];
+  const errors: { device: DeviceMeta; error: { code: string; message: string } }[] = [];
 
   for (const result of group.results) {
     if (result.success && result.data?.found) {
       const { found: _foundFlag, ...rest } = result.data;
       found.push({ device: result.device, ...rest } as { device: DeviceMeta } & T);
-    } else {
-      notFound.push({
-        device: result.device,
-        reason: result.error?.message ?? "Element not found",
-      });
+      continue;
     }
+    if (!result.success && result.error) {
+      errors.push({ device: result.device, error: result.error });
+      notFound.push({ device: result.device, reason: result.error.message });
+      continue;
+    }
+    notFound.push({ device: result.device, reason: "Element not found" });
   }
 
   return {
@@ -124,5 +133,6 @@ export async function executeSmartQuery<T extends Record<string, unknown>>(
     deviceCount: devices.length,
     found,
     notFound,
+    errors,
   };
 }

--- a/packages/cli/src/mcp/jsonrpc.ts
+++ b/packages/cli/src/mcp/jsonrpc.ts
@@ -1,0 +1,170 @@
+/**
+ * JSON-RPC 2.0 envelope validation.
+ *
+ * The MCP SDK trusts its inputs; for the HTTP transport we sit in front of it
+ * and reject malformed envelopes with the spec error code -32600 (Invalid
+ * Request) before they reach the SDK. This catches accidental misuse and
+ * blocks unrelated JSON traffic from being interpreted as MCP messages.
+ *
+ * Spec: https://www.jsonrpc.org/specification
+ */
+
+export const INVALID_REQUEST_CODE = -32600;
+export const PARSE_ERROR_CODE = -32700;
+
+export interface JsonRpcError {
+  code: number;
+  message: string;
+}
+
+export interface JsonRpcErrorResponse {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  error: JsonRpcError;
+}
+
+export type ValidationResult =
+  | { ok: true }
+  | { ok: false; error: JsonRpcError; id: string | number | null };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isValidId(value: unknown): value is string | number | null {
+  if (value === null) return true;
+  if (typeof value === "string") return true;
+  // JSON-RPC 2.0 forbids fractional numeric ids; accept integers only.
+  return typeof value === "number" && Number.isFinite(value) && Number.isInteger(value);
+}
+
+function extractId(envelope: Record<string, unknown>): string | number | null {
+  const id = envelope.id;
+  return isValidId(id) ? id : null;
+}
+
+/**
+ * Validate a single JSON-RPC 2.0 envelope. The envelope may be a request,
+ * notification, response, or error response.
+ */
+export function validateEnvelope(value: unknown): ValidationResult {
+  if (!isPlainObject(value)) {
+    return {
+      ok: false,
+      id: null,
+      error: { code: INVALID_REQUEST_CODE, message: "Invalid Request: envelope must be a JSON object" },
+    };
+  }
+
+  if (value.jsonrpc !== "2.0") {
+    return {
+      ok: false,
+      id: extractId(value),
+      error: { code: INVALID_REQUEST_CODE, message: "Invalid Request: jsonrpc must be the string \"2.0\"" },
+    };
+  }
+
+  const hasMethod = "method" in value;
+  const hasResult = "result" in value;
+  const hasError = "error" in value;
+  const hasId = "id" in value;
+
+  // Response or error response: must have id (may be null for parse errors),
+  // and exactly one of result/error.
+  if (!hasMethod) {
+    if (!hasId) {
+      return {
+        ok: false,
+        id: null,
+        error: { code: INVALID_REQUEST_CODE, message: "Invalid Request: response envelope missing id" },
+      };
+    }
+    if (!isValidId(value.id)) {
+      return {
+        ok: false,
+        id: null,
+        error: { code: INVALID_REQUEST_CODE, message: "Invalid Request: id must be a string, integer, or null" },
+      };
+    }
+    if (hasResult === hasError) {
+      return {
+        ok: false,
+        id: extractId(value),
+        error: { code: INVALID_REQUEST_CODE, message: "Invalid Request: response must contain exactly one of result or error" },
+      };
+    }
+    if (hasError && !isPlainObject(value.error)) {
+      return {
+        ok: false,
+        id: extractId(value),
+        error: { code: INVALID_REQUEST_CODE, message: "Invalid Request: error must be a JSON object" },
+      };
+    }
+    if (hasError) {
+      const errObj = value.error as Record<string, unknown>;
+      if (typeof errObj.code !== "number" || !Number.isInteger(errObj.code) || typeof errObj.message !== "string") {
+        return {
+          ok: false,
+          id: extractId(value),
+          error: { code: INVALID_REQUEST_CODE, message: "Invalid Request: error must have integer code and string message" },
+        };
+      }
+    }
+    return { ok: true };
+  }
+
+  // Request or notification: method is required and must be a string.
+  if (typeof value.method !== "string") {
+    return {
+      ok: false,
+      id: extractId(value),
+      error: { code: INVALID_REQUEST_CODE, message: "Invalid Request: method must be a string" },
+    };
+  }
+
+  // If id is present, it must be string/number/null. Notifications omit id.
+  if (hasId && !isValidId(value.id)) {
+    return {
+      ok: false,
+      id: null,
+      error: { code: INVALID_REQUEST_CODE, message: "Invalid Request: id must be a string, integer, or null" },
+    };
+  }
+
+  // params, if present, must be a structured value (object or array).
+  if ("params" in value && !isPlainObject(value.params) && !Array.isArray(value.params)) {
+    return {
+      ok: false,
+      id: extractId(value),
+      error: { code: INVALID_REQUEST_CODE, message: "Invalid Request: params must be an array or object" },
+    };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Validate a payload that may be a single envelope or a batch (array) of
+ * envelopes. Returns the first validation error encountered, or { ok: true }.
+ */
+export function validatePayload(value: unknown): ValidationResult {
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return {
+        ok: false,
+        id: null,
+        error: { code: INVALID_REQUEST_CODE, message: "Invalid Request: batch must not be empty" },
+      };
+    }
+    for (const entry of value) {
+      const result = validateEnvelope(entry);
+      if (!result.ok) return result;
+    }
+    return { ok: true };
+  }
+  return validateEnvelope(value);
+}
+
+export function makeErrorResponse(id: string | number | null, error: JsonRpcError): JsonRpcErrorResponse {
+  return { jsonrpc: "2.0", id, error };
+}

--- a/packages/cli/src/mcp/transport.ts
+++ b/packages/cli/src/mcp/transport.ts
@@ -1,11 +1,81 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { createServer } from "node:http";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  makeErrorResponse,
+  PARSE_ERROR_CODE,
+  validatePayload,
+} from "./jsonrpc.js";
 
 export async function startStdio(server: McpServer): Promise<void> {
   const transport = new StdioServerTransport();
   await server.connect(transport);
+}
+
+const MAX_BODY_BYTES = 1_048_576; // 1 MiB — generous for MCP envelopes; rejects accidental floods.
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    req.on("data", (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > MAX_BODY_BYTES) {
+        reject(new Error("payload too large"));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      resolve(Buffer.concat(chunks).toString("utf8"));
+    });
+    req.on("error", reject);
+  });
+}
+
+function writeJsonRpcError(
+  res: ServerResponse,
+  status: number,
+  id: string | number | null,
+  code: number,
+  message: string,
+): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(makeErrorResponse(id, { code, message })));
+}
+
+async function handleMcpPost(
+  transport: StreamableHTTPServerTransport,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  let raw: string;
+  try {
+    raw = await readBody(req);
+  } catch (err) {
+    writeJsonRpcError(res, 413, null, PARSE_ERROR_CODE, (err as Error).message);
+    return;
+  }
+
+  // Empty body is allowed for some non-POST routes; on POST it is invalid JSON.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    writeJsonRpcError(res, 400, null, PARSE_ERROR_CODE, "Parse error: invalid JSON");
+    return;
+  }
+
+  const validation = validatePayload(parsed);
+  if (!validation.ok) {
+    writeJsonRpcError(res, 400, validation.id, validation.error.code, validation.error.message);
+    return;
+  }
+
+  await transport.handleRequest(req, res, parsed);
 }
 
 export async function startHttp(server: McpServer, port: number): Promise<void> {
@@ -14,7 +84,10 @@ export async function startHttp(server: McpServer, port: number): Promise<void> 
   const httpServer = createServer((req, res) => {
     const url = new URL(req.url ?? "/", `http://localhost:${port}`);
     if (url.pathname === "/mcp") {
-      transport.handleRequest(req, res).catch((err: unknown) => {
+      const handler = req.method === "POST"
+        ? handleMcpPost(transport, req, res)
+        : transport.handleRequest(req, res);
+      handler.catch((err: unknown) => {
         console.error("MCP transport error:", err);
         if (!res.headersSent) {
           res.writeHead(500);

--- a/packages/cli/tests/commands/group.test.ts
+++ b/packages/cli/tests/commands/group.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Command } from "commander";
+import { addDevice, clearDevices } from "../../src/discovery/registry.js";
+import { registerGroup } from "../../src/commands/group.js";
+import type { DiscoveredDevice } from "../../src/types.js";
+
+function makeDevice(overrides: Partial<DiscoveredDevice> = {}): DiscoveredDevice {
+  return {
+    id: "d1",
+    name: "iPhone",
+    ip: "192.168.1.10",
+    port: 8420,
+    platform: "ios",
+    model: "iPhone 15",
+    width: 390,
+    height: 844,
+    version: "1.0.0",
+    lastSeen: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeProgram(): Command {
+  const program = new Command();
+  program
+    .name("kelpie")
+    .option("--device <id>")
+    .option("--format <type>", "Output format", "json")
+    .option("--timeout <ms>", "Timeout", (v: string) => Number(v), 10000)
+    .option("--port <port>", "Port", (v: string) => Number(v), 8420);
+  registerGroup(program);
+  return program;
+}
+
+describe("kelpie group <command> --allow-partial", () => {
+  const originalFetch = globalThis.fetch;
+  const originalExitCode = process.exitCode;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    clearDevices();
+    addDevice(makeDevice({ id: "d1", name: "iPhone" }));
+    addDevice(makeDevice({ id: "d2", name: "Pixel", ip: "192.168.1.11" }));
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    process.exitCode = originalExitCode;
+    logSpy.mockRestore();
+    clearDevices();
+  });
+
+  function mockMixedResults(): void {
+    let call = 0;
+    globalThis.fetch = vi.fn(async () => {
+      call++;
+      if (call === 2) {
+        return new Response(
+          JSON.stringify({ success: false, error: { code: "NAVIGATION_ERROR", message: "DNS failed" } }),
+          { status: 502, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+  }
+
+  it("surfaces per-device failures in output", async () => {
+    mockMixedResults();
+    const program = makeProgram();
+    await program.parseAsync(["node", "kelpie", "group", "navigate", "https://example.com"]);
+
+    const lastCall = logSpy.mock.calls[logSpy.mock.calls.length - 1]?.[0] as string;
+    const printed = JSON.parse(lastCall) as {
+      succeeded: number;
+      failed: number;
+      results: { success: boolean; error?: { code: string; message: string } }[];
+    };
+    expect(printed.succeeded).toBe(1);
+    expect(printed.failed).toBe(1);
+    const failure = printed.results.find((r) => !r.success);
+    expect(failure?.error?.code).toBe("NAVIGATION_ERROR");
+    expect(failure?.error?.message).toBe("DNS failed");
+  });
+
+  it("sets non-zero exit code by default when any device fails", async () => {
+    mockMixedResults();
+    const program = makeProgram();
+    await program.parseAsync(["node", "kelpie", "group", "navigate", "https://example.com"]);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("keeps exit code 0 with --allow-partial when some devices fail", async () => {
+    mockMixedResults();
+    const program = makeProgram();
+    await program.parseAsync([
+      "node",
+      "kelpie",
+      "group",
+      "navigate",
+      "https://example.com",
+      "--allow-partial",
+    ]);
+    expect(process.exitCode).toBeFalsy();
+  });
+
+  it("keeps exit code 0 when every device succeeds, regardless of --allow-partial", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ) as typeof fetch;
+
+    const program = makeProgram();
+    await program.parseAsync(["node", "kelpie", "group", "navigate", "https://example.com"]);
+    expect(process.exitCode).toBeFalsy();
+  });
+
+  it("smart query: --allow-partial suppresses non-zero exit on device error", async () => {
+    let call = 0;
+    globalThis.fetch = vi.fn(async () => {
+      call++;
+      if (call === 1) {
+        return new Response(JSON.stringify({ found: false }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({ success: false, error: { code: "WEBVIEW_OFFLINE", message: "no view" } }),
+        { status: 500, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const program = makeProgram();
+    await program.parseAsync([
+      "node",
+      "kelpie",
+      "group",
+      "find-button",
+      "Submit",
+      "--allow-partial",
+    ]);
+    expect(process.exitCode).toBeFalsy();
+  });
+
+  it("smart query: non-zero exit on device error without --allow-partial", async () => {
+    let call = 0;
+    globalThis.fetch = vi.fn(async () => {
+      call++;
+      if (call === 1) {
+        return new Response(JSON.stringify({ found: false }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({ success: false, error: { code: "WEBVIEW_OFFLINE", message: "no view" } }),
+        { status: 500, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const program = makeProgram();
+    await program.parseAsync(["node", "kelpie", "group", "find-button", "Submit"]);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("smart query: exit code unaffected by genuine 'not found' (no device errors)", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ found: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ) as typeof fetch;
+
+    const program = makeProgram();
+    await program.parseAsync(["node", "kelpie", "group", "find-button", "Submit"]);
+    expect(process.exitCode).toBeFalsy();
+  });
+});

--- a/packages/cli/tests/discovery/registry.test.ts
+++ b/packages/cli/tests/discovery/registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -10,6 +10,7 @@ import {
   getAllDevices,
   clearDevices,
   deviceCount,
+  TTL_MS,
 } from "../../src/discovery/registry.js";
 import type { DiscoveredDevice } from "../../src/types.js";
 import { setRunningBrowser, upsertBrowserAlias } from "../../src/browser/store.js";
@@ -122,6 +123,40 @@ describe("device registry", () => {
     expect(device?.ip).toBe("127.0.0.1");
     expect(device?.port).toBe(8427);
     expect(device?.platform).toBe("macos");
+  });
+
+  it("evicts devices whose lastSeen is older than the mDNS TTL on read", async () => {
+    const now = 1_000_000_000_000;
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(now);
+      addDevice(makeDevice({ id: "fresh", name: "Fresh", lastSeen: now - (TTL_MS - 1000) }));
+      addDevice(makeDevice({ id: "stale", name: "Stale", lastSeen: now - (TTL_MS + 1000) }));
+
+      const all = getAllDevices();
+      expect(all.map((d) => d.id).sort()).toEqual(["fresh"]);
+      expect(deviceCount()).toBe(1);
+
+      // Stale device must not be resolvable by name lookup either.
+      expect(await getDevice("Stale")).toBeUndefined();
+      expect((await getDevice("Fresh"))?.id).toBe("fresh");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("re-announcement refreshes lastSeen and prevents eviction", () => {
+    const now = 1_000_000_000_000;
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(now);
+      addDevice(makeDevice({ id: "d", lastSeen: now - (TTL_MS + 1000) }));
+      // Re-announcement (same id, fresh lastSeen).
+      addDevice(makeDevice({ id: "d", lastSeen: now }));
+      expect(getAllDevices()).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("stores linux and windows devices without coercing their platform metadata", () => {

--- a/packages/cli/tests/group/orchestrator.test.ts
+++ b/packages/cli/tests/group/orchestrator.test.ts
@@ -123,5 +123,33 @@ describe("executeSmartQuery", () => {
     expect(result.found).toHaveLength(2);
     expect(result.notFound).toHaveLength(1);
     expect(result.notFound[0].device.name).toBe("iPad");
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("separates device errors from genuine not-found responses", async () => {
+    let callIndex = 0;
+    globalThis.fetch = vi.fn(async () => {
+      callIndex++;
+      if (callIndex === 1) {
+        return new Response(JSON.stringify({ found: true, element: { tag: "button" } }), { status: 200 });
+      }
+      if (callIndex === 2) {
+        // Real device error — must surface as an error, not a quiet "not found".
+        return new Response(
+          JSON.stringify({ success: false, error: { code: "WEBVIEW_OFFLINE", message: "no view" } }),
+          { status: 500 },
+        );
+      }
+      return new Response(JSON.stringify({ found: false }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await executeSmartQuery(devices, "findButton", { text: "Submit" }, 5000);
+    expect(result.found).toHaveLength(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].error.code).toBe("WEBVIEW_OFFLINE");
+    // The errored device also appears in notFound (with its error message as reason)
+    // so existing JSON consumers keep seeing it, but the new errors[] array is
+    // what the CLI checks to flip exit code.
+    expect(result.notFound).toHaveLength(2);
   });
 });

--- a/packages/cli/tests/mcp/jsonrpc.test.ts
+++ b/packages/cli/tests/mcp/jsonrpc.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  INVALID_REQUEST_CODE,
+  validateEnvelope,
+  validatePayload,
+} from "../../src/mcp/jsonrpc.js";
+
+describe("validateEnvelope", () => {
+  it("accepts a well-formed request", () => {
+    expect(validateEnvelope({ jsonrpc: "2.0", id: 1, method: "ping" })).toEqual({ ok: true });
+  });
+
+  it("accepts a notification (no id)", () => {
+    expect(validateEnvelope({ jsonrpc: "2.0", method: "notify" })).toEqual({ ok: true });
+  });
+
+  it("accepts a string id", () => {
+    expect(validateEnvelope({ jsonrpc: "2.0", id: "abc", method: "ping" })).toEqual({ ok: true });
+  });
+
+  it("accepts a null id on a request (allowed by spec)", () => {
+    expect(validateEnvelope({ jsonrpc: "2.0", id: null, method: "ping" })).toEqual({ ok: true });
+  });
+
+  it("accepts a successful response", () => {
+    expect(validateEnvelope({ jsonrpc: "2.0", id: 1, result: { ok: true } })).toEqual({ ok: true });
+  });
+
+  it("accepts an error response", () => {
+    expect(
+      validateEnvelope({ jsonrpc: "2.0", id: 1, error: { code: -32601, message: "Method not found" } }),
+    ).toEqual({ ok: true });
+  });
+
+  it("accepts params as object or array", () => {
+    expect(validateEnvelope({ jsonrpc: "2.0", id: 1, method: "x", params: { a: 1 } })).toEqual({ ok: true });
+    expect(validateEnvelope({ jsonrpc: "2.0", id: 2, method: "x", params: [1, 2] })).toEqual({ ok: true });
+  });
+
+  it("rejects non-objects", () => {
+    for (const v of [null, undefined, 42, "hi", true, [1]]) {
+      const r = validateEnvelope(v);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error.code).toBe(INVALID_REQUEST_CODE);
+    }
+  });
+
+  it("rejects missing or wrong jsonrpc version", () => {
+    const r = validateEnvelope({ id: 1, method: "ping" });
+    expect(r.ok).toBe(false);
+    const r2 = validateEnvelope({ jsonrpc: "1.0", id: 1, method: "ping" });
+    expect(r2.ok).toBe(false);
+  });
+
+  it("rejects non-string method on requests", () => {
+    const r = validateEnvelope({ jsonrpc: "2.0", id: 1, method: 5 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.code).toBe(INVALID_REQUEST_CODE);
+      expect(r.id).toBe(1);
+    }
+  });
+
+  it("rejects fractional or non-finite id", () => {
+    expect(validateEnvelope({ jsonrpc: "2.0", id: 1.5, method: "x" }).ok).toBe(false);
+    expect(validateEnvelope({ jsonrpc: "2.0", id: Number.NaN, method: "x" }).ok).toBe(false);
+  });
+
+  it("rejects object/array id", () => {
+    expect(validateEnvelope({ jsonrpc: "2.0", id: { a: 1 }, method: "x" }).ok).toBe(false);
+    expect(validateEnvelope({ jsonrpc: "2.0", id: [1], method: "x" }).ok).toBe(false);
+  });
+
+  it("rejects non-structured params", () => {
+    expect(validateEnvelope({ jsonrpc: "2.0", id: 1, method: "x", params: "nope" }).ok).toBe(false);
+  });
+
+  it("rejects response with both result and error", () => {
+    expect(
+      validateEnvelope({ jsonrpc: "2.0", id: 1, result: {}, error: { code: 1, message: "x" } }).ok,
+    ).toBe(false);
+  });
+
+  it("rejects response with neither result nor error", () => {
+    expect(validateEnvelope({ jsonrpc: "2.0", id: 1 }).ok).toBe(false);
+  });
+
+  it("rejects response missing id", () => {
+    expect(validateEnvelope({ jsonrpc: "2.0", result: {} }).ok).toBe(false);
+  });
+
+  it("rejects error response with malformed error object", () => {
+    expect(validateEnvelope({ jsonrpc: "2.0", id: 1, error: { message: "x" } }).ok).toBe(false);
+    expect(validateEnvelope({ jsonrpc: "2.0", id: 1, error: { code: "x", message: "x" } }).ok).toBe(false);
+    expect(validateEnvelope({ jsonrpc: "2.0", id: 1, error: "nope" }).ok).toBe(false);
+  });
+});
+
+describe("validatePayload", () => {
+  it("accepts a batch of valid envelopes", () => {
+    expect(
+      validatePayload([
+        { jsonrpc: "2.0", id: 1, method: "a" },
+        { jsonrpc: "2.0", method: "b" },
+      ]),
+    ).toEqual({ ok: true });
+  });
+
+  it("rejects empty batch", () => {
+    const r = validatePayload([]);
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects batch with one malformed entry", () => {
+    const r = validatePayload([
+      { jsonrpc: "2.0", id: 1, method: "a" },
+      { jsonrpc: "1.0", id: 2, method: "b" },
+    ]);
+    expect(r.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Three independent CLI/MCP hardening fixes, each in its own commit.

- **JSON-RPC envelope validation (2959c80)**: the HTTP MCP transport previously forwarded any JSON object to the SDK without checking it was a valid JSON-RPC 2.0 envelope. Adds a hand-rolled validator covering requests, notifications, responses, errors, and batches. Parse errors emit `-32700`; envelope errors emit `-32600`.
- **Device registry TTL eviction (175b276)**: stale devices that never sent an mDNS goodbye lingered forever and the CLI would route commands to dead targets. Adds a 90s TTL on `lastSeen`, evicted inline on every read. Re-announcement refreshes the entry via the existing `addDevice` path.
- **Per-device error surfacing + `--allow-partial` (1fdc610)**: the group orchestrator hid per-device failures from scripts (no exit-code signal) and `executeSmartQuery` collapsed real transport errors into `notFound[]`. Now every device failure carries a full `{code, message}` envelope, smart queries partition transport errors into a dedicated `errors[]` array, and `kelpie group …` exits non-zero by default if any device failed. Pass `--allow-partial` to suppress the non-zero exit. Documented in `docs/cli.md`.

## Test plan

- [x] `pnpm -w lint` passes
- [x] `pnpm -w build` passes
- [x] `pnpm -w test` — 334 tests pass across 21 files
- [x] New tests: JSON-RPC envelope validation (20), registry TTL eviction + re-announcement refresh (2), orchestrator mixed success/failure + smart query error partitioning (2), CLI `--allow-partial` exit-code behaviour for both regular group commands and smart queries (7)
- [x] Rebased cleanly on latest `origin/main` (no conflicts with #56, #57)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>