### PR TITLE
fix: CEF/WebKit headless navigation, background server start, tap diagnostics, CLI discovery

### DIFF
--- a/apps/android/app/src/main/java/com/kelpie/browser/handlers/InteractionHandler.kt
+++ b/apps/android/app/src/main/java/com/kelpie/browser/handlers/InteractionHandler.kt
@@ -290,6 +290,7 @@ class InteractionHandler(
     private fun tapScript(execution: TapExecution): String =
         """
         (function() {
+            ${elementSelectorBuilderScript()}
             ${interactionHelpersScript()}
             var requestedX = ${execution.requestedX};
             var requestedY = ${execution.requestedY};

--- a/apps/ios/Kelpie/Handlers/InteractionHandler.swift
+++ b/apps/ios/Kelpie/Handlers/InteractionHandler.swift
@@ -313,6 +313,7 @@ struct InteractionHandler {
     private func tapScript(execution: TapExecution) -> String {
         """
         (function() {
+            \(elementSelectorBuilderScript())
             \(interactionHelpersScript())
             var requestedX = \(execution.requestedX);
             var requestedY = \(execution.requestedY);

--- a/apps/macos/Kelpie/Handlers/HandlerContext.swift
+++ b/apps/macos/Kelpie/Handlers/HandlerContext.swift
@@ -380,9 +380,18 @@ final class HandlerContext {
         )
     }
 
-    func load(url: URL) {
+    /// Side-effects every navigation must run regardless of which renderer is
+    /// driven: notify the shell (URL-bar / loading UI) and tear down the 3D
+    /// inspector. Exposed so handlers can drive the resolved renderer directly,
+    /// keeping navigate targeting the same renderer that reads resolve to even
+    /// when no window has rendered to wire `renderer` to the active tab.
+    func prepareForNavigation() {
         WindowRegistry.shared.defaultEntry()?.callbacks?.onWillLoad()
         reset3DInspectorForNavigation()
+    }
+
+    func load(url: URL) {
+        prepareForNavigation()
         renderer?.load(url: url)
     }
 

--- a/apps/macos/Kelpie/Handlers/HandlerContext.swift
+++ b/apps/macos/Kelpie/Handlers/HandlerContext.swift
@@ -6,6 +6,12 @@ final class HandlerContext {
     nonisolated static let defaultOverlayRGB = "59,130,246"
 
     var renderer: (any RendererEngine)?
+    /// True while the Chromium (CEF) engine is active. CEF is a single-renderer
+    /// engine — it has no per-tab WebKit renderers — so renderer resolution must
+    /// target `renderer` (the live CEF instance) rather than the tab store's
+    /// hidden about:blank `WKWebViewRenderer`. Kept in sync by ServerState
+    /// wherever the active renderer changes.
+    var activeEngineIsChromium = false
     var consoleMessages: [[String: Any]] = []
     var isIn3DInspector = false
     var scriptPlaybackState: ScriptPlaybackState?
@@ -39,6 +45,17 @@ final class HandlerContext {
     /// tab windows reject empty `tabId` so LLMs are forced to be explicit
     /// about which tab they target.
     func resolveRenderer(windowId: String?, tabId: String?) throws -> any RendererEngine {
+        // Chromium (CEF) is a single-renderer engine. Tabs are modeled only for
+        // WebKit, so resolving through the tab store here would return a hidden
+        // WKWebViewRenderer that never navigated (stuck on about:blank): navigate
+        // would drive the live CEF renderer while eval/dom/screenshot read the
+        // blank WebView (issues #74/#77/#78/#79). Target the live renderer
+        // directly; windowId/tabId do not apply in single-renderer mode.
+        if activeEngineIsChromium {
+            guard let renderer else { throw HandlerError.noWebView }
+            return renderer
+        }
+
         if let windowId, WindowRegistry.shared.entry(for: windowId) == nil {
             throw HandlerError.windowNotFound(windowId)
         }

--- a/apps/macos/Kelpie/Handlers/InteractionHandler.swift
+++ b/apps/macos/Kelpie/Handlers/InteractionHandler.swift
@@ -346,6 +346,7 @@ struct InteractionHandler {
     private func tapScript(execution: TapExecution) -> String {
         """
         (function() {
+            \(elementSelectorBuilderScript())
             \(interactionHelpersScript())
             var requestedX = \(execution.requestedX);
             var requestedY = \(execution.requestedY);

--- a/apps/macos/Kelpie/Handlers/NavigationHandler.swift
+++ b/apps/macos/Kelpie/Handlers/NavigationHandler.swift
@@ -129,7 +129,12 @@ struct NavigationHandler {
         let windowId = HandlerContext.windowId(from: body)
         // Prefer the active tab's own stored state — context.renderer may lag
         // behind tab switches, returning a stale inactive tab's URL (issue #17).
+        // This tab-store shortcut is WebKit-only: in Chromium (CEF) mode the
+        // tab store holds a hidden about:blank WKWebViewRenderer, so reading it
+        // would report "Start Page" while CEF is on a real page (#78). CEF falls
+        // through to the live renderer via resolveRenderer below.
         if tabId == nil,
+           !context.activeEngineIsChromium,
            let store = context.tabStore(windowId: windowId, tabId: nil),
            let tab = store.activeTab {
             return ["url": tab.currentURL, "title": tab.title]

--- a/apps/macos/Kelpie/Handlers/NavigationHandler.swift
+++ b/apps/macos/Kelpie/Handlers/NavigationHandler.swift
@@ -39,18 +39,21 @@ struct NavigationHandler {
 
             let loadTime = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
             let finalURL = renderer.currentURL?.absoluteString ?? ""
-            // Honest failure: a renderer still parked on about:blank / no URL after
-            // the load window means the navigation never took effect (e.g. a
-            // renderer resolution mismatch). Report it instead of a false success
-            // that leaves callers reading a blank document (#78/#79).
-            if finalURL.isEmpty || finalURL == "about:blank" {
+            // Honest failure (Chromium only): after a real load CEF reports the
+            // live document URL, so a renderer still on about:blank / no URL here
+            // means the page never loaded — report it instead of a false success
+            // that leaves callers reading a blank document (#78/#79). WebKit
+            // updates currentURL asynchronously (KVO), so a blank check there
+            // would false-positive on fast or redirecting loads; keep WebKit's
+            // lenient fallback to the requested URL.
+            if context.activeEngineIsChromium, finalURL.isEmpty || finalURL == "about:blank" {
                 return errorResponse(
                     code: "NAVIGATION_ERROR",
                     message: "Navigation to \(urlString) did not load — the active renderer is still blank."
                 )
             }
             return successResponse([
-                "url": finalURL,
+                "url": finalURL.isEmpty ? urlString : finalURL,
                 "title": renderer.currentTitle,
                 "loadTime": loadTime
             ])

--- a/apps/macos/Kelpie/Handlers/NavigationHandler.swift
+++ b/apps/macos/Kelpie/Handlers/NavigationHandler.swift
@@ -26,11 +26,11 @@ struct NavigationHandler {
         do {
             let renderer = try context.resolveRenderer(tabId: tabId)
             let start = CFAbsoluteTimeGetCurrent()
-            if tabId == nil {
-                context.load(url: url)
-            } else {
-                renderer.load(url: url)
-            }
+            // Drive the SAME renderer reads resolve to, so navigate works even
+            // when no window has rendered to wire context.renderer to the active
+            // tab — i.e. headless / background, the MCP-controlled mode (#78).
+            context.prepareForNavigation()
+            renderer.load(url: url)
 
             for _ in 0..<100 {
                 try? await Task.sleep(nanoseconds: 100_000_000)

--- a/apps/macos/Kelpie/Handlers/NavigationHandler.swift
+++ b/apps/macos/Kelpie/Handlers/NavigationHandler.swift
@@ -38,8 +38,19 @@ struct NavigationHandler {
             }
 
             let loadTime = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+            let finalURL = renderer.currentURL?.absoluteString ?? ""
+            // Honest failure: a renderer still parked on about:blank / no URL after
+            // the load window means the navigation never took effect (e.g. a
+            // renderer resolution mismatch). Report it instead of a false success
+            // that leaves callers reading a blank document (#78/#79).
+            if finalURL.isEmpty || finalURL == "about:blank" {
+                return errorResponse(
+                    code: "NAVIGATION_ERROR",
+                    message: "Navigation to \(urlString) did not load — the active renderer is still blank."
+                )
+            }
             return successResponse([
-                "url": renderer.currentURL?.absoluteString ?? urlString,
+                "url": finalURL,
                 "title": renderer.currentTitle,
                 "loadTime": loadTime
             ])

--- a/apps/macos/Kelpie/Info.plist
+++ b/apps/macos/Kelpie/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.6</string>
+	<string>0.1.7</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/apps/macos/Kelpie/KelpieApp.swift
+++ b/apps/macos/Kelpie/KelpieApp.swift
@@ -243,13 +243,25 @@ private struct BrowserCommands: Commands {
 @main
 struct KelpieApp: App {
     @StateObject private var browserState = BrowserState()
-    @StateObject private var rendererState = RendererState()
+    @StateObject private var rendererState: RendererState
     @StateObject private var serverState: ServerState
 
     init() {
         let launchPort = Self.launchPortArgument() ?? 8420
-        _serverState = StateObject(wrappedValue: ServerState(port: UInt16(launchPort)))
+        let server = ServerState(port: UInt16(launchPort))
+        let renderer = RendererState()
+        _serverState = StateObject(wrappedValue: server)
+        _rendererState = StateObject(wrappedValue: renderer)
         _ = AIState.shared
+        // Kelpie is driven headlessly over HTTP/MCP and must be reachable
+        // whenever the process is alive, not only when a window is foregrounded.
+        // Gating server start on the window's onAppear meant a background launch
+        // never started the server, so the device never became discoverable
+        // (#75, and the NO_DEVICES reports). Start it eagerly at launch; the
+        // onAppear call below is a redundant, idempotent safety net.
+        Task { @MainActor in
+            Self.startServices(serverState: server, rendererState: renderer)
+        }
     }
 
     var body: some Scene {
@@ -260,7 +272,7 @@ struct KelpieApp: App {
                 rendererState: rendererState,
                 viewportState: serverState.viewportState
             )
-            .onAppear { startServices() }
+            .onAppear { Self.startServices(serverState: serverState, rendererState: rendererState) }
             .frame(
                 minWidth: ViewportState.minimumShellSize.width,
                 minHeight: ViewportState.minimumShellSize.height
@@ -275,10 +287,10 @@ struct KelpieApp: App {
         }
     }
 
-    private func startServices() {
+    private static func startServices(serverState: ServerState, rendererState: RendererState) {
         serverState.startHTTPServer(rendererState: rendererState)
         #if DEBUG
-        if Self.canBind(port: 8421) {
+        if canBind(port: 8421) {
             AppReveal.start(port: 8421)
         } else {
             print("[KelpieApp] Skipping AppReveal start because port 8421 is already in use")

--- a/apps/macos/Kelpie/Network/ServerState.swift
+++ b/apps/macos/Kelpie/Network/ServerState.swift
@@ -54,6 +54,9 @@ final class ServerState: ObservableObject {
     /// here (not as a separate property assignment) so handler registration
     /// can read it without force-unwrapping.
     func startHTTPServer(rendererState: RendererState) {
+        // Idempotent: the server is started eagerly at app launch and again from
+        // the window's onAppear safety net — only the first call binds the socket.
+        guard httpServer == nil else { return }
         self.rendererState = rendererState
         let preferredPort = UInt16(deviceInfo.port)
         let resolvedPort = Self.firstAvailablePort(startingAt: preferredPort)

--- a/apps/macos/Kelpie/Network/ServerState.swift
+++ b/apps/macos/Kelpie/Network/ServerState.swift
@@ -35,6 +35,7 @@ final class ServerState: ObservableObject {
         }
         wkRenderer = renderer
         handlerContext.renderer = renderer
+        handlerContext.activeEngineIsChromium = false
     }
     private(set) var cefRenderer: CEFRenderer?
 
@@ -73,6 +74,7 @@ final class ServerState: ObservableObject {
         let startEngine = rendererState.activeEngine
         let activeRenderer = renderer(for: startEngine)
         handlerContext.renderer = activeRenderer
+        handlerContext.activeEngineIsChromium = (startEngine == .chromium)
         handlerContext.startSharedCookieSync()
 
         registerHandlers(rendererState: rendererState)
@@ -243,6 +245,7 @@ final class ServerState: ObservableObject {
         await handlerContext.persistRendererCookiesToSharedJar()
         await CookieMigrator.migrate(from: source, to: target)
         handlerContext.renderer = target
+        handlerContext.activeEngineIsChromium = (engine == .chromium)
         await handlerContext.syncSharedCookiesIntoRenderer(force: true)
 
         // Load the same URL in the target renderer

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,6 +44,8 @@ kelpie discover --scan-timeout 5000    # custom mDNS scan duration in ms
 
 `--scan-timeout` controls how long the mDNS scan runs. The global `--timeout` flag, by contrast, governs the per-request timeout used by individual device commands and has no effect on `discover`.
 
+mDNS announcements are racy. If the scan finds no devices, the CLI falls back to probing `127.0.0.1` directly (the recorded running ports plus `8420`–`8429`) so a Kelpie running on the same host still appears. This same localhost fallback is used whenever a command runs without `--device` and the scan comes up empty.
+
 **Output:**
 ```json
 {
@@ -90,6 +92,8 @@ kelpie browser register codex-b --app /Applications/Kelpie.app
 
 ### `kelpie browser launch <name>`
 Launch a new local macOS Kelpie app instance for a registered alias. If `--port` is omitted, the CLI auto-selects the first safe free port and skips reserved ports such as `8421` used by AppReveal and CLI MCP.
+
+If the requested port is already held by a stale instance, the macOS app falls back to the next free port. After launching, the CLI polls the fallback range and records the port the new instance actually bound, so the saved alias stays reachable.
 
 ```bash
 kelpie browser launch claude-a

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlikeotherai/kelpie",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "Apache-2.0",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/browser.ts
+++ b/packages/cli/src/commands/browser.ts
@@ -5,6 +5,7 @@ import { promisify } from "node:util";
 import { DEFAULT_PORT } from "@unlikeotherai/kelpie-shared";
 import type { Command } from "commander";
 import { print } from "../output/formatter.js";
+import { probeHealth } from "../discovery/local-probe.js";
 import type { GlobalOptions } from "../types.js";
 import {
   clearRunningBrowser,
@@ -17,16 +18,18 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+/** How many ports above the requested one the macOS app may fall back to. */
+const PORT_FALLBACK_RANGE = 10;
+/** How long to wait for a freshly launched instance to bind a port. */
+const LAUNCH_BIND_TIMEOUT_MS = 12_000;
+/** How often to re-probe while waiting for the launched instance to bind. */
+const LAUNCH_BIND_POLL_MS = 400;
+
 async function isReachable(port?: number): Promise<boolean> {
   if (!port) {
     return false;
   }
-  try {
-    const response = await fetch(`http://127.0.0.1:${port}/health`);
-    return response.ok;
-  } catch {
-    return false;
-  }
+  return probeHealth(port);
 }
 
 function chooseLaunchPort(requestedPort?: string): number {
@@ -34,6 +37,46 @@ function chooseLaunchPort(requestedPort?: string): number {
     return Number(requestedPort);
   }
   return DEFAULT_PORT;
+}
+
+function fallbackPorts(requestedPort: number): number[] {
+  return Array.from({ length: PORT_FALLBACK_RANGE }, (_value, index) => requestedPort + index);
+}
+
+/** Ports in the fallback range already reachable before launch (stale instances). */
+async function reachablePorts(ports: number[]): Promise<Set<number>> {
+  const checks = await Promise.all(
+    ports.map(async (port) => ({ port, reachable: await probeHealth(port) })),
+  );
+  return new Set(checks.filter((check) => check.reachable).map((check) => check.port));
+}
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * The macOS app falls back to the next free port when the requested one is held
+ * by a stale instance. Poll the fallback range for a port that became reachable
+ * after launch (i.e. was not reachable before) so the store records the real
+ * bound port. Prefer the requested port when it newly comes up.
+ */
+async function waitForBoundPort(
+  requestedPort: number,
+  preLaunchReachable: Set<number>,
+): Promise<number | undefined> {
+  const ports = fallbackPorts(requestedPort);
+  const deadline = Date.now() + LAUNCH_BIND_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const nowReachable = await reachablePorts(ports);
+    const fresh = ports.filter((port) => nowReachable.has(port) && !preLaunchReachable.has(port));
+    if (fresh.includes(requestedPort)) {
+      return requestedPort;
+    }
+    if (fresh.length > 0) {
+      return fresh[0];
+    }
+    await delay(LAUNCH_BIND_POLL_MS);
+  }
+  return undefined;
 }
 
 export function registerBrowser(program: Command): void {
@@ -135,9 +178,11 @@ export function registerBrowser(program: Command): void {
       }
 
       try {
+        const preLaunchReachable = await reachablePorts(fallbackPorts(port));
         await execFileAsync("open", ["-na", appPath, "--args", "--port", String(port)]);
-        await setRunningBrowser(name, { port, lastLaunchedAt: new Date().toISOString() });
-        print({ success: true, name, platform: alias.platform, appPath, port }, globals.format);
+        const boundPort = (await waitForBoundPort(port, preLaunchReachable)) ?? port;
+        await setRunningBrowser(name, { port: boundPort, lastLaunchedAt: new Date().toISOString() });
+        print({ success: true, name, platform: alias.platform, appPath, port: boundPort }, globals.format);
       } catch (error) {
         await clearRunningBrowser(name);
         print({

--- a/packages/cli/src/commands/browser.ts
+++ b/packages/cli/src/commands/browser.ts
@@ -43,13 +43,22 @@ function fallbackPorts(requestedPort: number): number[] {
   return Array.from({ length: PORT_FALLBACK_RANGE }, (_value, index) => requestedPort + index);
 }
 
-/** Ports in the fallback range already reachable before launch (stale instances). */
-async function reachablePorts(ports: number[]): Promise<Set<number>> {
+/**
+ * Ports in the fallback range already reachable before launch (stale instances).
+ * The pre-launch snapshot uses a longer timeout so a healthy-but-busy instance
+ * holding the requested port is reliably classified as already-running — a
+ * false negative there would let waitForBoundPort mistake the old instance for
+ * the freshly launched one.
+ */
+export async function reachablePorts(ports: number[], timeoutMs = 600): Promise<Set<number>> {
   const checks = await Promise.all(
-    ports.map(async (port) => ({ port, reachable: await probeHealth(port) })),
+    ports.map(async (port) => ({ port, reachable: await probeHealth(port, timeoutMs) })),
   );
   return new Set(checks.filter((check) => check.reachable).map((check) => check.port));
 }
+
+/** Pre-launch snapshot timeout: generous so a live instance is never missed. */
+const PRE_LAUNCH_PROBE_TIMEOUT_MS = 2_000;
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -59,13 +68,14 @@ const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
  * after launch (i.e. was not reachable before) so the store records the real
  * bound port. Prefer the requested port when it newly comes up.
  */
-async function waitForBoundPort(
+export async function waitForBoundPort(
   requestedPort: number,
   preLaunchReachable: Set<number>,
+  now: () => number = Date.now,
 ): Promise<number | undefined> {
   const ports = fallbackPorts(requestedPort);
-  const deadline = Date.now() + LAUNCH_BIND_TIMEOUT_MS;
-  while (Date.now() < deadline) {
+  const deadline = now() + LAUNCH_BIND_TIMEOUT_MS;
+  while (now() < deadline) {
     const nowReachable = await reachablePorts(ports);
     const fresh = ports.filter((port) => nowReachable.has(port) && !preLaunchReachable.has(port));
     if (fresh.includes(requestedPort)) {
@@ -178,7 +188,7 @@ export function registerBrowser(program: Command): void {
       }
 
       try {
-        const preLaunchReachable = await reachablePorts(fallbackPorts(port));
+        const preLaunchReachable = await reachablePorts(fallbackPorts(port), PRE_LAUNCH_PROBE_TIMEOUT_MS);
         await execFileAsync("open", ["-na", appPath, "--args", "--port", String(port)]);
         const boundPort = (await waitForBoundPort(port, preLaunchReachable)) ?? port;
         await setRunningBrowser(name, { port: boundPort, lastLaunchedAt: new Date().toISOString() });

--- a/packages/cli/src/commands/discover.ts
+++ b/packages/cli/src/commands/discover.ts
@@ -4,7 +4,7 @@ import { enrichDevicesWithCapabilities } from "../discovery/capabilities.js";
 import { probeLocalDevices } from "../discovery/local-probe.js";
 import { addDevices } from "../discovery/registry.js";
 import { print } from "../output/formatter.js";
-import type { DiscoveredDevice, GlobalOptions } from "../types.js";
+import type { GlobalOptions } from "../types.js";
 
 export function registerDiscover(program: Command): void {
   program
@@ -17,22 +17,12 @@ export function registerDiscover(program: Command): void {
       const duration = Number(opts.scanTimeout);
       const devices = await enrichDevicesWithCapabilities(await scanForDevices(duration));
       // mDNS is racy; if the browse came up empty, probe localhost so a
-      // same-host Kelpie still shows up in `kelpie devices`.
+      // same-host Kelpie still shows up in `kelpie devices`. probeLocalDevices
+      // already returns one device per port.
       if (devices.length === 0) {
-        devices.push(...dedupeByPort(await probeLocalDevices()));
+        devices.push(...(await probeLocalDevices()));
       }
       addDevices(devices);
       print({ devices, count: devices.length }, globals.format);
     });
-}
-
-function dedupeByPort(devices: DiscoveredDevice[]): DiscoveredDevice[] {
-  const seen = new Set<number>();
-  return devices.filter((device) => {
-    if (seen.has(device.port)) {
-      return false;
-    }
-    seen.add(device.port);
-    return true;
-  });
 }

--- a/packages/cli/src/commands/discover.ts
+++ b/packages/cli/src/commands/discover.ts
@@ -1,9 +1,10 @@
 import type { Command } from "commander";
 import { scanForDevices } from "../discovery/scanner.js";
 import { enrichDevicesWithCapabilities } from "../discovery/capabilities.js";
+import { probeLocalDevices } from "../discovery/local-probe.js";
 import { addDevices } from "../discovery/registry.js";
 import { print } from "../output/formatter.js";
-import type { GlobalOptions } from "../types.js";
+import type { DiscoveredDevice, GlobalOptions } from "../types.js";
 
 export function registerDiscover(program: Command): void {
   program
@@ -15,7 +16,23 @@ export function registerDiscover(program: Command): void {
       const globals = program.opts<GlobalOptions>();
       const duration = Number(opts.scanTimeout);
       const devices = await enrichDevicesWithCapabilities(await scanForDevices(duration));
+      // mDNS is racy; if the browse came up empty, probe localhost so a
+      // same-host Kelpie still shows up in `kelpie devices`.
+      if (devices.length === 0) {
+        devices.push(...dedupeByPort(await probeLocalDevices()));
+      }
       addDevices(devices);
       print({ devices, count: devices.length }, globals.format);
     });
+}
+
+function dedupeByPort(devices: DiscoveredDevice[]): DiscoveredDevice[] {
+  const seen = new Set<number>();
+  return devices.filter((device) => {
+    if (seen.has(device.port)) {
+      return false;
+    }
+    seen.add(device.port);
+    return true;
+  });
 }

--- a/packages/cli/src/commands/helpers.ts
+++ b/packages/cli/src/commands/helpers.ts
@@ -35,6 +35,12 @@ export async function requireDevice(program: Command): Promise<DiscoveredDevice 
   if (getAllDevices().length === 0) {
     addDevices(await scanForDevices(2500));
   }
+  // mDNS is racy; a Kelpie on this host is reachable on 127.0.0.1 even when the
+  // browse misses its announcement. Fall back to a direct localhost probe.
+  if (getAllDevices().length === 0) {
+    const { probeLocalDevices } = await import("../discovery/local-probe.js");
+    addDevices(await probeLocalDevices());
+  }
   const all = getAllDevices();
   if (all.length === 1) return all[0];
   if (all.length === 0) {

--- a/packages/cli/src/discovery/local-probe.ts
+++ b/packages/cli/src/discovery/local-probe.ts
@@ -1,0 +1,89 @@
+import { DEFAULT_PORT } from "@unlikeotherai/kelpie-shared";
+import type { DiscoveredDevice } from "../types.js";
+import { loadBrowserStore } from "../browser/store.js";
+
+/**
+ * mDNS announcements are racy: a Kelpie on the same host is reachable on
+ * 127.0.0.1 long before (or without ever) winning the browse. Probe the local
+ * /health endpoint directly so the CLI self-heals when discovery misses.
+ */
+
+/** How many ports above DEFAULT_PORT to sweep when probing localhost. */
+const LOCAL_PORT_SWEEP = 10;
+
+/** Probe a single localhost port's /health endpoint. Returns false on any error. */
+export async function probeHealth(port: number, timeoutMs = 600): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/health`, { signal: controller.signal });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Candidate ports: every recorded running port plus the default sweep range. */
+function candidatePorts(store: Awaited<ReturnType<typeof loadBrowserStore>>): number[] {
+  const ports = new Set<number>();
+  for (const running of Object.values(store.running)) {
+    ports.add(running.port);
+  }
+  for (let i = 0; i < LOCAL_PORT_SWEEP; i++) {
+    ports.add(DEFAULT_PORT + i);
+  }
+  return Array.from(ports);
+}
+
+/** Reverse-lookup the alias whose running port matches, for naming/platform. */
+function aliasForPort(
+  store: Awaited<ReturnType<typeof loadBrowserStore>>,
+  port: number,
+): { name: string; platform: DiscoveredDevice["platform"] } | undefined {
+  for (const [name, running] of Object.entries(store.running)) {
+    if (running.port === port) {
+      return { name, platform: store.aliases[name]?.platform ?? "macos" };
+    }
+  }
+  return undefined;
+}
+
+function localDevice(
+  store: Awaited<ReturnType<typeof loadBrowserStore>>,
+  port: number,
+): DiscoveredDevice {
+  const alias = aliasForPort(store, port);
+  const platform = alias?.platform ?? "macos";
+  return {
+    id: `local:127.0.0.1:${port}`,
+    name: alias?.name ?? `localhost:${port}`,
+    ip: "127.0.0.1",
+    port,
+    platform,
+    model: `Kelpie ${platform}`,
+    width: 0,
+    height: 0,
+    version: "0.0.0",
+    lastSeen: Date.now(),
+  };
+}
+
+/**
+ * Probe localhost for reachable Kelpie instances. Candidate ports are the union
+ * of every recorded running port and DEFAULT_PORT..DEFAULT_PORT+9, probed in
+ * parallel. Deduped by port.
+ */
+export async function probeLocalDevices(): Promise<DiscoveredDevice[]> {
+  const store = await loadBrowserStore();
+  const ports = candidatePorts(store);
+  const results = await Promise.all(
+    ports.map(async (port) => ({ port, reachable: await probeHealth(port) })),
+  );
+  return results
+    .filter((result) => result.reachable)
+    .map((result) => localDevice(store, result.port));
+}

--- a/packages/cli/tests/commands/browser-launch-port.test.ts
+++ b/packages/cli/tests/commands/browser-launch-port.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/discovery/local-probe.js", () => ({
+  probeHealth: vi.fn(),
+}));
+
+import { probeHealth } from "../../src/discovery/local-probe.js";
+import { waitForBoundPort, reachablePorts } from "../../src/commands/browser.js";
+
+const mockProbe = vi.mocked(probeHealth);
+
+/** Make exactly the given ports respond to /health. */
+function reachable(...ports: number[]): void {
+  mockProbe.mockImplementation(async (port: number) => ports.includes(port));
+}
+
+describe("reachablePorts", () => {
+  beforeEach(() => mockProbe.mockReset());
+
+  it("returns only the reachable ports", async () => {
+    reachable(8420, 8422);
+    const set = await reachablePorts([8420, 8421, 8422]);
+    expect([...set].sort((a, b) => a - b)).toEqual([8420, 8422]);
+  });
+});
+
+describe("waitForBoundPort", () => {
+  beforeEach(() => mockProbe.mockReset());
+
+  it("records the requested port when nothing held it before launch", async () => {
+    reachable(8420);
+    expect(await waitForBoundPort(8420, new Set())).toBe(8420);
+  });
+
+  it("records the fallback port when a stale instance held the requested port", async () => {
+    // Both up after launch, but 8420 was already reachable pre-launch.
+    reachable(8420, 8421);
+    expect(await waitForBoundPort(8420, new Set([8420]))).toBe(8421);
+  });
+
+  it("does not mistake a recovered stale instance on the requested port for the new one", async () => {
+    // 8420 (stale) correctly captured pre-launch; new instance bound 8421.
+    reachable(8420, 8421);
+    expect(await waitForBoundPort(8420, new Set([8420]))).not.toBe(8420);
+  });
+
+  it("returns undefined when no new instance binds before the deadline", async () => {
+    reachable(8420); // only the pre-existing instance stays up
+    let calls = 0;
+    const clock = (): number => (calls++ === 0 ? 0 : 999_999);
+    expect(await waitForBoundPort(8420, new Set([8420]), clock)).toBeUndefined();
+  });
+});

--- a/packages/cli/tests/commands/require-device-localhost.test.ts
+++ b/packages/cli/tests/commands/require-device-localhost.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { DEFAULT_PORT } from "@unlikeotherai/kelpie-shared";
+import { requireDevice } from "../../src/commands/helpers.js";
+import { clearDevices } from "../../src/discovery/registry.js";
+
+// mDNS browse returns nothing; the localhost probe must self-heal.
+vi.mock("../../src/discovery/scanner.js", () => ({
+  scanForDevices: vi.fn(async () => []),
+}));
+
+function programWithoutDevice(): Command {
+  const program = new Command();
+  // requireDevice reads program.opts(); no --device is set so the auto-scan
+  // path runs. A json format keeps any error output quiet/structured.
+  program.setOptionValue("format", "json");
+  return program;
+}
+
+describe("requireDevice localhost fallback", () => {
+  const originalHome = process.env.HOME;
+  let homeDir = "";
+
+  beforeEach(async () => {
+    clearDevices();
+    homeDir = await mkdtemp(path.join(os.tmpdir(), "kelpie-require-device-"));
+    process.env.HOME = homeDir;
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    process.env.HOME = originalHome;
+    await rm(homeDir, { recursive: true, force: true });
+  });
+
+  it("falls back to a localhost device when the mDNS scan is empty", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request) => {
+        const target = String(url);
+        if (target.includes(`:${DEFAULT_PORT}/health`)) {
+          return new Response("ok", { status: 200 });
+        }
+        throw new Error("connection refused");
+      }),
+    );
+
+    const device = await requireDevice(programWithoutDevice());
+    expect(device).not.toBeNull();
+    expect(device?.ip).toBe("127.0.0.1");
+    expect(device?.port).toBe(DEFAULT_PORT);
+    expect(device?.id).toBe(`local:127.0.0.1:${DEFAULT_PORT}`);
+  });
+
+  it("returns NO_DEVICES when neither mDNS nor localhost respond", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("connection refused");
+      }),
+    );
+
+    const device = await requireDevice(programWithoutDevice());
+    expect(device).toBeNull();
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
+  });
+});

--- a/packages/cli/tests/discovery/local-probe.test.ts
+++ b/packages/cli/tests/discovery/local-probe.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DEFAULT_PORT } from "@unlikeotherai/kelpie-shared";
+import { probeHealth, probeLocalDevices } from "../../src/discovery/local-probe.js";
+import { setRunningBrowser, upsertBrowserAlias } from "../../src/browser/store.js";
+
+/** Stub fetch so only the given localhost ports answer /health with 200. */
+function stubReachablePorts(ports: number[]): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string | URL | Request) => {
+      const target = String(url);
+      const ok = ports.some((port) => target.includes(`:${port}/health`));
+      if (!ok) {
+        throw new Error("connection refused");
+      }
+      return new Response("ok", { status: 200 });
+    }),
+  );
+}
+
+describe("local-probe", () => {
+  const originalHome = process.env.HOME;
+  let homeDir = "";
+
+  beforeEach(async () => {
+    homeDir = await mkdtemp(path.join(os.tmpdir(), "kelpie-local-probe-"));
+    process.env.HOME = homeDir;
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    process.env.HOME = originalHome;
+    await rm(homeDir, { recursive: true, force: true });
+  });
+
+  describe("probeHealth", () => {
+    it("returns true when /health responds ok", async () => {
+      stubReachablePorts([DEFAULT_PORT]);
+      expect(await probeHealth(DEFAULT_PORT)).toBe(true);
+    });
+
+    it("returns false when fetch rejects", async () => {
+      stubReachablePorts([]);
+      expect(await probeHealth(DEFAULT_PORT)).toBe(false);
+    });
+
+    it("returns false when the response is not ok", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => new Response("nope", { status: 503 })),
+      );
+      expect(await probeHealth(DEFAULT_PORT)).toBe(false);
+    });
+  });
+
+  describe("probeLocalDevices", () => {
+    it("returns a device for each reachable default-range port", async () => {
+      stubReachablePorts([DEFAULT_PORT]);
+      const devices = await probeLocalDevices();
+      expect(devices).toHaveLength(1);
+      const [device] = devices;
+      expect(device.id).toBe(`local:127.0.0.1:${DEFAULT_PORT}`);
+      expect(device.ip).toBe("127.0.0.1");
+      expect(device.port).toBe(DEFAULT_PORT);
+      expect(device.name).toBe(`localhost:${DEFAULT_PORT}`);
+      expect(device.platform).toBe("macos");
+    });
+
+    it("skips unreachable ports", async () => {
+      stubReachablePorts([]);
+      expect(await probeLocalDevices()).toEqual([]);
+    });
+
+    it("includes ports recorded in the browser store", async () => {
+      const storePort = DEFAULT_PORT + 50; // outside the default sweep range
+      await upsertBrowserAlias("claude-a", { platform: "macos" });
+      await setRunningBrowser("claude-a", {
+        port: storePort,
+        lastLaunchedAt: "2026-04-01T09:00:00.000Z",
+      });
+      stubReachablePorts([storePort]);
+
+      const devices = await probeLocalDevices();
+      expect(devices).toHaveLength(1);
+      const [device] = devices;
+      expect(device.port).toBe(storePort);
+      // The matching alias supplies name + platform.
+      expect(device.name).toBe("claude-a");
+      expect(device.platform).toBe("macos");
+    });
+
+    it("dedupes when a stored running port overlaps the default sweep", async () => {
+      await upsertBrowserAlias("claude-a", { platform: "macos" });
+      await setRunningBrowser("claude-a", {
+        port: DEFAULT_PORT,
+        lastLaunchedAt: "2026-04-01T09:00:00.000Z",
+      });
+      stubReachablePorts([DEFAULT_PORT]);
+
+      const devices = await probeLocalDevices();
+      expect(devices).toHaveLength(1);
+      expect(devices[0].port).toBe(DEFAULT_PORT);
+      expect(devices[0].name).toBe("claude-a");
+    });
+  });
+});


### PR DESCRIPTION
Sweep of open GitHub issues. All macOS changes were verified live against the app **running in the background** (no window focus), on both the WebKit and Chromium (CEF) engines.

## Root causes & fixes

**Reads went to a hidden about:blank renderer in CEF mode** — `resolveRenderer` returned the active tab's WKWebViewRenderer (never navigated) instead of the live CEF renderer, so navigate drove CEF while eval/dom/query/screenshot read a blank WebView, and `get-current-url` reported "Start Page". Now reads/navigate resolve to the live renderer in chromium mode. Fixes #74, #77, #78, #79, #76.

**Server only started when a window rendered** — `startHTTPServer` ran from the window's `.onAppear`, so a background launch (the MCP-controlled mode) never started the server and the device never became discoverable. Now the server starts eagerly at app launch (idempotent). Fixes #75, #21, #37, #38.

**navigate/read renderer split (headless)** — navigate drove `context.renderer` while reads resolved to the active tab's renderer; these only unify once a window renders. navigate now drives the same renderer reads resolve to, plus an honest `NAVIGATION_ERROR` (Chromium only) instead of false success.

**tap returned EVAL_ERROR on real elements** — `tapScript` injected `interactionHelpersScript()` but not `elementSelectorBuilderScript()`, so the diagnostics path hit `kelpieBuildSelector is not defined`. Fixed on macOS/iOS/Android. Fixes #39.

**CLI discovery flakiness** — `requireDevice`/`devices` now fall back to a localhost `/health` probe when the mDNS browse is empty; `browser launch` records the actually-bound port. (Reaches users with the CLI 0.1.7 npm publish.)

## Verification
- macOS app run in the background; WebKit + CEF both: navigate → real URL/title, get-current-url → real URL, eval → real page, screenshot → real page, tap → success with a built selector (no EVAL_ERROR).
- CLI: lint clean, build success, 359 tests pass.
- Adversarial review run on the diff; findings addressed (WebKit honest-failure gating, port-reconcile hardening + tests).

## Versions
- macOS app 0.1.7 (build 6); CLI 0.1.7.
- iOS/Android received the tap fix in source; they ship in their own release cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)