### PR TITLE
[codex] fix linux release asset publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
                 curl \
                 file \
                 fontconfig-devel \
+                gcc-c++ \
                 git \
                 glib2-devel \
                 gtk3-devel \

--- a/packaging/linux/runtime-files.txt
+++ b/packaging/linux/runtime-files.txt
@@ -3,7 +3,6 @@ chrome-sandbox
 chrome_100_percent.pak
 chrome_200_percent.pak
 icon-1024.png
-kelpie.png
 icudtl.dat
 libEGL.so
 libGLESv2.so


### PR DESCRIPTION
## Summary

- remove the stale `kelpie.png` runtime manifest entry that the Linux build never produces
- install Fedora's `gcc-c++` package explicitly so CMake can configure C++ projects in the release container

## Root Cause

The failed `release/2026-06-13` run had two independent Linux packaging defects: Ubuntu completed the build but the bundle step required `apps/linux/build/kelpie.png`, while the CMake target only produces `icon-1024.png`; Fedora installed C tooling through `@development-tools` but did not provide a discoverable C++ compiler for the CEF wrapper configure step.

## Validation

- parsed `.github/workflows/release.yml` with Python/YAML
- built a synthetic Linux runtime bundle from `packaging/linux/runtime-files.txt`
- ran `git diff --check`
