### PR TITLE
[codex] keep Linux release rpath relocatable

### DIFF
--- a/apps/linux/CMakeLists.txt
+++ b/apps/linux/CMakeLists.txt
@@ -162,6 +162,9 @@ endif()
 set_target_properties(kelpie-linux PROPERTIES
   OUTPUT_NAME "kelpie-linux"
   BUILD_RPATH "\$ORIGIN"
+  BUILD_WITH_INSTALL_RPATH TRUE
+  INSTALL_RPATH "\$ORIGIN"
+  INSTALL_RPATH_USE_LINK_PATH FALSE
 )
 
 add_custom_command(TARGET kelpie-linux POST_BUILD


### PR DESCRIPTION
## Summary

- force the Linux app target to build with its install RPATH
- keep packaged Linux binaries on `$ORIGIN` instead of inheriting absolute CEF cache paths

## Root Cause

The Linux release workflow packages `apps/linux/build/kelpie-linux` directly. Because the target links to CEF through an absolute SDK path, CMake appended that CEF `Release` directory to the build-tree RUNPATH. Fedora RPM QA rejects that as an invalid runpath because the package bundles CEF beside the binary.

## Validation

- `cmake -S apps/linux -B /tmp/kelpie-linux-cmake-rpath-check -G Ninja -DKELPIE_LINUX_HEADLESS_ONLY=ON`
- Fedora Docker CMake proof linking an executable to an absolute shared library path and verifying `readelf` reports `RUNPATH=$ORIGIN`
- `git diff --check`

Fixes #106.
