### PR TITLE
[codex] fix AppImage extraction path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,12 @@ jobs:
                   if [ "${BUILD_APPIMAGE}" = "true" ]; then
                     curl -L --fail -o /tmp/appimagetool.AppImage "${APPIMAGETOOL_URL}"
                     chmod 755 /tmp/appimagetool.AppImage
-                    APPIMAGE_EXTRACT_AND_RUN=1 /tmp/appimagetool.AppImage --appimage-extract >/dev/null
+                    rm -rf /tmp/squashfs-root
+                    (
+                      cd /tmp
+                      APPIMAGE_EXTRACT_AND_RUN=1 /tmp/appimagetool.AppImage --appimage-extract >/dev/null
+                    )
+                    test -x /tmp/squashfs-root/AppRun
                     bash scripts/package-linux-appimage.sh \
                       --version "${VERSION}" \
                       --bundle-dir "${bundle_root}/kelpie-linux" \


### PR DESCRIPTION
## Summary

- extract `appimagetool` from `/tmp` so `squashfs-root` is created where the workflow expects it
- remove stale extraction output before each release build
- assert the extracted AppRun exists before invoking the AppImage packaging script

## Root Cause

`appimagetool.AppImage --appimage-extract` creates `squashfs-root` in the current working directory. The release workflow extracted from `/workspace` but passed `/tmp/squashfs-root/AppRun` into `scripts/package-linux-appimage.sh`, so Ubuntu releases failed after building the `.deb`.

## Validation

- parsed `.github/workflows/release.yml` with Python/YAML
- ran `git diff --check`
- inspected `release/2026-06-13.2` Ubuntu logs showing extraction reached the package script and only the extracted path was missing

Fixes #108.
