### PR TITLE
Fix Linux package repository asset discovery

### DIFF
--- a/scripts/build-linux-package-repos.sh
+++ b/scripts/build-linux-package-repos.sh
@@ -51,6 +51,17 @@ mkdir -p "${APT_ROOT}" "${RPM_ROOT}"
 mapfile -t TAGS < <(gh api --paginate "repos/${REPOSITORY}/releases" --jq '.[] | select(.draft == false) | .tag_name')
 
 for tag in "${TAGS[@]}"; do
+  has_linux_packages="$(
+    gh release view "${tag}" \
+      --repo "${REPOSITORY}" \
+      --json assets \
+      --jq 'any(.assets[].name; test("\\.(deb|rpm)$"))'
+  )"
+
+  if [ "${has_linux_packages}" != "true" ]; then
+    continue
+  fi
+
   gh release download "${tag}" \
     --repo "${REPOSITORY}" \
     --dir "${ASSET_DIR}" \
@@ -58,6 +69,15 @@ for tag in "${TAGS[@]}"; do
     --pattern '*.rpm' \
     --skip-existing
 done
+
+shopt -s nullglob
+downloaded_packages=("${ASSET_DIR}"/*.deb "${ASSET_DIR}"/*.rpm)
+shopt -u nullglob
+
+if [ "${#downloaded_packages[@]}" -eq 0 ]; then
+  echo "no .deb or .rpm assets downloaded" >&2
+  exit 1
+fi
 
 APT_POOL="${APT_ROOT}/pool/main/m/kelpie"
 APT_DIST="${APT_ROOT}/dists/stable/main/binary-amd64"


### PR DESCRIPTION
## Summary
- skip releases that do not contain Linux package assets when building package repositories
- keep failing clearly if no .deb or .rpm assets are downloaded at all

## Root cause
The package repository publishing script iterated every non-draft release and called gh release download with .deb/.rpm patterns. gh exits non-zero with "no assets to download" for releases without matching assets, so the script aborted before reaching release/2026-06-13.4, even though that release had uploaded Linux assets.

Fixes #112.

## Verification
- bash -n scripts/build-linux-package-repos.sh
- git diff --check
- local fake-gh package-repo run with one empty release and one Linux-package release, verifying generated APT/RPM files