### PR TITLE
Fail releases when npm publish token is missing for new packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,12 +338,12 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
-          if [ -z "${NODE_AUTH_TOKEN}" ]; then
-            exit 0
-          fi
           version="$(node -p "require('./packages/shared/package.json').version")"
           if npm view "@unlikeotherai/kelpie-shared@${version}" version >/dev/null 2>&1; then
             echo "@unlikeotherai/kelpie-shared@${version} already published"
+          elif [ -z "${NODE_AUTH_TOKEN}" ]; then
+            echo "NPM_TOKEN is required to publish @unlikeotherai/kelpie-shared@${version}" >&2
+            exit 1
           else
             cd packages/shared && npm publish --access public --provenance
           fi
@@ -353,12 +353,12 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
-          if [ -z "${NODE_AUTH_TOKEN}" ]; then
-            exit 0
-          fi
           version="$(node -p "require('./packages/cli/package.json').version")"
           if npm view "@unlikeotherai/kelpie@${version}" version >/dev/null 2>&1; then
             echo "@unlikeotherai/kelpie@${version} already published"
+          elif [ -z "${NODE_AUTH_TOKEN}" ]; then
+            echo "NPM_TOKEN is required to publish @unlikeotherai/kelpie@${version}" >&2
+            exit 1
           else
             cd packages/cli && npm publish --access public --provenance
           fi


### PR DESCRIPTION
## Summary
- check whether shared/CLI package versions already exist before requiring npm credentials
- fail release jobs if a package version is missing and NPM_TOKEN is unavailable

## Root cause
release/2026-06-13.5 reported a successful CLI publish step even though @unlikeotherai/kelpie@0.1.8 was not on npm. The workflow exited successfully as soon as NODE_AUTH_TOKEN was empty, before checking whether the package version already existed.

I manually published @unlikeotherai/kelpie@0.1.8 from the verified main checkout. This PR prevents the same false-green behavior for future versions.

Fixes #114.

## Verification
- ruby -e 'require yaml; YAML.load_file(.github/workflows/release.yml)'
- git diff --check
- empty-token guard simulation for already-published @unlikeotherai/kelpie-shared@0.1.0 and @unlikeotherai/kelpie@0.1.8