### PR TITLE
fix(macos): read live page metadata after navigation

### DIFF
--- a/apps/macos/Kelpie/Handlers/EvaluateHandler.swift
+++ b/apps/macos/Kelpie/Handlers/EvaluateHandler.swift
@@ -75,9 +75,10 @@ struct EvaluateHandler {
                 try? await Task.sleep(nanoseconds: 100_000_000)
                 if !renderer.isLoading {
                     let loadTime = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+                    let snapshot = await NavigationPageSnapshot.read(from: renderer)
                     return successResponse([
-                        "url": renderer.currentURL?.absoluteString ?? "",
-                        "title": renderer.currentTitle,
+                        "url": snapshot.url,
+                        "title": snapshot.title,
                         "loadTime": loadTime
                     ])
                 }

--- a/apps/macos/Kelpie/Handlers/NavigationHandler.swift
+++ b/apps/macos/Kelpie/Handlers/NavigationHandler.swift
@@ -38,7 +38,8 @@ struct NavigationHandler {
             }
 
             let loadTime = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
-            let finalURL = renderer.currentURL?.absoluteString ?? ""
+            let snapshot = await NavigationPageSnapshot.read(from: renderer, fallbackURL: urlString)
+            let finalURL = snapshot.url
             // Honest failure (Chromium only): after a real load CEF reports the
             // live document URL, so a renderer still on about:blank / no URL here
             // means the page never loaded — report it instead of a false success
@@ -54,7 +55,7 @@ struct NavigationHandler {
             }
             return successResponse([
                 "url": finalURL.isEmpty ? urlString : finalURL,
-                "title": renderer.currentTitle,
+                "title": snapshot.title,
                 "loadTime": loadTime
             ])
         } catch {
@@ -74,7 +75,8 @@ struct NavigationHandler {
                 renderer.goBack()
             }
             try? await Task.sleep(nanoseconds: 500_000_000)
-            return successResponse(["url": renderer.currentURL?.absoluteString ?? "", "title": renderer.currentTitle])
+            let snapshot = await NavigationPageSnapshot.read(from: renderer)
+            return successResponse(["url": snapshot.url, "title": snapshot.title])
         } catch {
             if let tabError = tabErrorResponse(from: error) { return tabError }
             return errorResponse(code: "NO_WEBVIEW", message: error.localizedDescription)
@@ -92,7 +94,8 @@ struct NavigationHandler {
                 renderer.goForward()
             }
             try? await Task.sleep(nanoseconds: 500_000_000)
-            return successResponse(["url": renderer.currentURL?.absoluteString ?? "", "title": renderer.currentTitle])
+            let snapshot = await NavigationPageSnapshot.read(from: renderer)
+            return successResponse(["url": snapshot.url, "title": snapshot.title])
         } catch {
             if let tabError = tabErrorResponse(from: error) { return tabError }
             return errorResponse(code: "NO_WEBVIEW", message: error.localizedDescription)
@@ -115,9 +118,10 @@ struct NavigationHandler {
                 if !renderer.isLoading { break }
             }
             let loadTime = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+            let snapshot = await NavigationPageSnapshot.read(from: renderer)
             return successResponse([
-                "url": renderer.currentURL?.absoluteString ?? "",
-                "title": renderer.currentTitle,
+                "url": snapshot.url,
+                "title": snapshot.title,
                 "loadTime": loadTime
             ])
         } catch {

--- a/apps/macos/Kelpie/Handlers/NavigationPageSnapshot.swift
+++ b/apps/macos/Kelpie/Handlers/NavigationPageSnapshot.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+struct NavigationPageSnapshot {
+    let url: String
+    let title: String
+
+    @MainActor
+    static func read(from renderer: any RendererEngine, fallbackURL: String? = nil) async -> Self {
+        let fallback = Self(
+            url: renderer.currentURL?.absoluteString ?? fallbackURL ?? "",
+            title: renderer.currentTitle
+        )
+        let script = """
+        JSON.stringify({
+            url: window.location.href || '',
+            title: document.title || ''
+        })
+        """
+
+        do {
+            let result = try await renderer.evaluateJS(script)
+            guard let payload = payload(from: result) else {
+                return fallback
+            }
+            let liveURL = payload["url"] as? String
+            let liveTitle = payload["title"] as? String
+            let resolvedURL: String
+            if let liveURL, !liveURL.isEmpty {
+                resolvedURL = liveURL
+            } else {
+                resolvedURL = fallback.url
+            }
+            return Self(
+                url: resolvedURL,
+                title: liveTitle ?? fallback.title
+            )
+        } catch {
+            return fallback
+        }
+    }
+
+    private static func payload(from result: Any?) -> [String: Any]? {
+        if let payload = result as? [String: Any] {
+            return payload
+        }
+        guard let string = result as? String,
+              let data = string.data(using: .utf8),
+              let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return payload
+    }
+}

--- a/apps/macos/Kelpie/Handlers/ScriptHandler.swift
+++ b/apps/macos/Kelpie/Handlers/ScriptHandler.swift
@@ -240,7 +240,7 @@ struct ScriptHandler {
 
     @MainActor
     private func waitForNavigation(_ body: [String: Any]) async -> [String: Any] {
-        guard context.renderer != nil else {
+        guard let renderer = context.renderer else {
             return errorResponse(code: "NO_WEBVIEW", message: "No WebView")
         }
         let timeout = body["timeout"] as? Int ?? 10000
@@ -256,9 +256,10 @@ struct ScriptHandler {
                 observedLoading = true
             }
             if observedLoading, !isLoading {
+                let snapshot = await NavigationPageSnapshot.read(from: renderer)
                 return successResponse([
-                    "url": context.currentURL?.absoluteString ?? "",
-                    "title": context.currentTitle,
+                    "url": snapshot.url,
+                    "title": snapshot.title,
                     "loadTime": Int(Date().timeIntervalSince(start) * 1000)
                 ])
             }

--- a/apps/macos/Kelpie/Info.plist
+++ b/apps/macos/Kelpie/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.9</string>
+	<string>0.1.10</string>
 	<key>CFBundleVersion</key>
-	<string>8</string>
+	<string>9</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
## Summary
- read `location.href` and `document.title` from the live document before returning navigation metadata
- apply the same snapshot to navigate/back/forward/reload and wait-for-navigation responses
- bump macOS app to 0.1.10 build 9

Fixes #116.

## Verification
- `tuist generate`
- `cmake -S native -B native/.build -G Ninja && cmake --build native/.build`
- `make lint-swift && make macos-build`
- `pnpm lint && pnpm build && pnpm test`
- launched built macOS app 0.1.10 build 9 and verified localhost route change: `navigate /` returned `Kelpie Smoke Home`, `navigate /channels` returned `Kelpie Smoke Channels`, and `url`, `page-text`, and screenshot all succeeded

Note: the worktree needed local ignored vendor symlinks for AppReveal/CEF/llama during macOS build verification; those were removed before commit.
