### PR TITLE
Fix release package repository publishing warnings

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,19 +17,19 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.3
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4.0.1
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.5
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -17,10 +17,10 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.3
 
       - name: Install mise (tuist)
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v4.1.0
 
       - name: Vendor AppReveal (required by Project.swift)
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.3
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6.0.8
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,10 +17,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.3
 
       - name: Install mise (tuist)
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v4.1.0
 
       - name: Vendor AppReveal (required by Project.swift)
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.3
       - name: Install package repo tools
         run: |
           sudo apt-get update
@@ -40,9 +40,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           APT_GPG_KEY_ID: ${{ secrets.APT_GPG_KEY_ID }}
         run: bash scripts/build-linux-package-repos.sh --site-dir site
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@v6.0.0
+      - uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: site
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
             package_kind: rpm
             build_appimage: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.3
 
       - name: Build Linux packages
         env:
@@ -191,7 +191,7 @@ jobs:
               chmod -R a+rX dist/release
             '
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: linux-release-${{ matrix.distro.name }}
           path: |
@@ -206,14 +206,14 @@ jobs:
     name: Build Android release artifacts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.3
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
           java-version: '17'
 
-      - uses: android-actions/setup-android@v3
+      - uses: android-actions/setup-android@v4.0.1
 
       - name: Build Android APK and App Bundle
         env:
@@ -263,7 +263,7 @@ jobs:
             sha256sum ./*.apk ./*.aab > checksums.txt
           )
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: android-release
           path: |
@@ -279,13 +279,13 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.3
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.8
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 20
           cache: pnpm
@@ -363,7 +363,7 @@ jobs:
             cd packages/cli && npm publish --access public --provenance
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: cli-release
           path: |
@@ -379,18 +379,18 @@ jobs:
       - build-android
       - publish-cli
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8.0.1
         with:
           pattern: '*-release*'
           merge-multiple: true
           path: dist/release
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8.0.1
         with:
           name: cli-release
           path: dist/release/cli
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3.0.0
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |
@@ -409,7 +409,7 @@ jobs:
     needs:
       - attach-to-release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.3
 
       - name: Install package repo tools
         run: |
@@ -431,10 +431,10 @@ jobs:
           APT_GPG_KEY_ID: ${{ secrets.APT_GPG_KEY_ID }}
         run: bash scripts/build-linux-package-repos.sh --site-dir site
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6.0.0
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: site
 
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5.0.0

--- a/scripts/build-linux-package-repos.sh
+++ b/scripts/build-linux-package-repos.sh
@@ -48,9 +48,12 @@ mkdir -p "${ASSET_DIR}"
 rm -rf "${SITE_DIR}/packages"
 mkdir -p "${APT_ROOT}" "${RPM_ROOT}"
 
-mapfile -t TAGS < <(gh api --paginate "repos/${REPOSITORY}/releases" --jq '.[] | select(.draft == false) | .tag_name')
+PACKAGE_TAG=""
+while IFS= read -r tag; do
+  if [ -z "${tag}" ]; then
+    continue
+  fi
 
-for tag in "${TAGS[@]}"; do
   has_linux_packages="$(
     gh release view "${tag}" \
       --repo "${REPOSITORY}" \
@@ -62,13 +65,22 @@ for tag in "${TAGS[@]}"; do
     continue
   fi
 
-  gh release download "${tag}" \
-    --repo "${REPOSITORY}" \
-    --dir "${ASSET_DIR}" \
-    --pattern '*.deb' \
-    --pattern '*.rpm' \
-    --skip-existing
-done
+  PACKAGE_TAG="${tag}"
+  break
+done < <(gh api --paginate "repos/${REPOSITORY}/releases" --jq '.[] | select(.draft == false) | .tag_name')
+
+if [ -z "${PACKAGE_TAG}" ]; then
+  echo "no release with .deb or .rpm assets found" >&2
+  exit 1
+fi
+
+echo "building package repositories from release ${PACKAGE_TAG}"
+gh release download "${PACKAGE_TAG}" \
+  --repo "${REPOSITORY}" \
+  --dir "${ASSET_DIR}" \
+  --pattern '*.deb' \
+  --pattern '*.rpm' \
+  --skip-existing
 
 shopt -s nullglob
 downloaded_packages=("${ASSET_DIR}"/*.deb "${ASSET_DIR}"/*.rpm)
@@ -145,7 +157,7 @@ cat > "${SITE_DIR}/packages/index.html" <<EOF
   </head>
   <body>
     <h1>Kelpie Linux Packages</h1>
-    <p>Release automation publishes Linux packages here for manual download, APT, and DNF-compatible package managers.</p>
+    <p>Release automation publishes the latest Linux packages here for APT and DNF-compatible package managers.</p>
     <h2>APT (Debian and Ubuntu)</h2>
     <pre><code>${APT_INSTALL_COMMANDS}</code></pre>
     <h2>DNF / Yum (Fedora and compatible distros)</h2>
@@ -158,7 +170,7 @@ gpgcheck=0
 repo_gpgcheck=0
 REPO
 sudo dnf install kelpie</code></pre>
-    <p>Manual downloads remain available on the GitHub release page for <code>.tar.gz</code>, <code>.deb</code>, <code>.rpm</code>, and <code>.AppImage</code>.</p>
+    <p>Manual downloads and older package versions remain available on the GitHub release pages for <code>.tar.gz</code>, <code>.deb</code>, <code>.rpm</code>, and <code>.AppImage</code>.</p>
   </body>
 </html>
 EOF


### PR DESCRIPTION
## Summary
- publish Linux package repositories from the latest release that has `.deb`/`.rpm` assets instead of accumulating every historic release
- opt workflows into GitHub Actions Node 24 runtime before the forced migration
- make the package repo script portable to macOS Bash by replacing `mapfile`

## Verification
- `bash -n scripts/build-linux-package-repos.sh`
- YAML parsed for `.github/workflows/*.yml`
- mocked `scripts/build-linux-package-repos.sh --site-dir <tmp>` verified only `release/new` was downloaded and generated APT/RPM output

Closes #118