### PR TITLE
fix(macos): preserve default port after relaunch

### DIFF
--- a/apps/macos/Kelpie/Info.plist
+++ b/apps/macos/Kelpie/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.10</string>
+	<string>0.1.11</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>10</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/apps/macos/Kelpie/KelpieApp.swift
+++ b/apps/macos/Kelpie/KelpieApp.swift
@@ -375,6 +375,10 @@ struct KelpieApp: App {
         guard fd >= 0 else { return false }
         defer { close(fd) }
 
+        var reuseAddress: Int32 = 1
+        let optionLength = socklen_t(MemoryLayout<Int32>.size)
+        _ = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuseAddress, optionLength)
+
         var address = sockaddr_in6()
         address.sin6_len = UInt8(MemoryLayout<sockaddr_in6>.size)
         address.sin6_family = sa_family_t(AF_INET6)

--- a/apps/macos/Kelpie/Network/ServerState.swift
+++ b/apps/macos/Kelpie/Network/ServerState.swift
@@ -403,6 +403,10 @@ final class ServerState: ObservableObject {
         guard fd >= 0 else { return false }
         defer { close(fd) }
 
+        var reuseAddress: Int32 = 1
+        let optionLength = socklen_t(MemoryLayout<Int32>.size)
+        _ = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuseAddress, optionLength)
+
         var address = sockaddr_in6()
         address.sin6_len = UInt8(MemoryLayout<sockaddr_in6>.size)
         address.sin6_family = sa_family_t(AF_INET6)


### PR DESCRIPTION
## Summary
- set `SO_REUSEADDR` on macOS preflight bind probes so they match the real `NWListener` reuse behavior
- keep the browser HTTP server on documented default port `8420` after a fast relaunch
- bump macOS app to `0.1.11` build `10` for the required release cycle

Closes #120

## Root Cause
`HTTPServer` creates its `NWListener` with `allowLocalEndpointReuse = true`, but `ServerState.firstAvailablePort` used a raw probe socket without the matching reuse option. Immediately after relaunch, that probe could reject port `8420` while the actual listener would have been able to bind it, causing the app to fall forward to `8422`.

## Verification
- `tuist generate`
- `make lint-swift`
- `make macos-build`
- installed branch build to `/Applications/Kelpie.app`
- immediate quit/relaunch kept Kelpie listening on `*:8420`
- `curl http://127.0.0.1:8420/health` -> `{"status":"ok"}`
- `/v1/get-device-info` reports app `0.1.11` build `10`, network port `8420`
- `pnpm lint && pnpm build && pnpm test`
- CLI smoke: `kelpie info`, navigation to local smoke pages, `page-text`, `click`, `eval`, and `screenshot --output /tmp/kelpie-installed-011-port8420.png`