### PR TITLE
fix: accept public device info posts

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.kelpie.browser"
         minSdk = 28
         targetSdk = 34
-        versionCode = 1
-        versionName = "0.1.1"
+        versionCode = 2
+        versionName = "0.1.2"
 
         externalNativeBuild {
             cmake {

--- a/apps/android/app/src/main/java/com/kelpie/browser/network/HTTPServer.kt
+++ b/apps/android/app/src/main/java/com/kelpie/browser/network/HTTPServer.kt
@@ -182,19 +182,10 @@ class HTTPServer(
                             }
                         }
                         get("/get-device-info") {
-                            val parsed = parsedRequest(call)
-                            when (val decision = middleware.evaluate(parsed)) {
-                                is AuthDecision.Reject -> respondReject(call, decision)
-                                else -> {
-                                    val result =
-                                        pairEndpoints.handleGetDeviceInfo(
-                                            deviceInfo.name,
-                                            "android",
-                                            deviceInfo.version,
-                                        )
-                                    respondPairing(call, result.status, result.json, noStore = false)
-                                }
-                            }
+                            handlePublicDeviceInfo(call, middleware, pairEndpoints)
+                        }
+                        post("/get-device-info") {
+                            handlePublicDeviceInfo(call, middleware, pairEndpoints)
                         }
 
                         // --- Generic authenticated POST /v1/{method} ---
@@ -223,6 +214,26 @@ class HTTPServer(
         engine?.stop(1000, 2000)
         engine = null
         isRunning = false
+    }
+
+    private suspend fun handlePublicDeviceInfo(
+        call: ApplicationCall,
+        middleware: AuthMiddleware,
+        pairEndpoints: PairEndpoints,
+    ) {
+        val parsed = parsedRequest(call)
+        when (val decision = middleware.evaluate(parsed)) {
+            is AuthDecision.Reject -> respondReject(call, decision)
+            else -> {
+                val result =
+                    pairEndpoints.handleGetDeviceInfo(
+                        deviceInfo.name,
+                        "android",
+                        deviceInfo.version,
+                    )
+                respondPairing(call, result.status, result.json, noStore = false)
+            }
+        }
     }
 
     private suspend fun handleAuthenticatedPost(call: ApplicationCall) {

--- a/apps/ios/Kelpie/Network/HTTPServer.swift
+++ b/apps/ios/Kelpie/Network/HTTPServer.swift
@@ -278,7 +278,7 @@ final class HTTPServer: @unchecked Sendable {
                 connection: connection,
                 response: PairingHTTPResponse.json(status: result.status, json: result.json, noStore: true)
             )
-        case ("GET", "/v1/get-device-info"):
+        case ("GET", "/v1/get-device-info"), ("POST", "/v1/get-device-info"):
             let result = pairEndpoints.handleGetDeviceInfo(
                 name: deviceInfo.name,
                 platform: deviceInfo.platform,

--- a/apps/ios/Kelpie/Network/PairEndpoints.swift
+++ b/apps/ios/Kelpie/Network/PairEndpoints.swift
@@ -72,7 +72,7 @@ struct PairEndpoints {
         return (200, ["success": removed])
     }
 
-    /// GET /v1/get-device-info (unauthenticated, public capability advert).
+    /// GET or POST /v1/get-device-info (unauthenticated, public capability advert).
     func handleGetDeviceInfo(name: String, platform: String, version: String) -> (status: Int, json: [String: Any]) {
         (200, [
             "name": name,

--- a/apps/ios/Project.swift
+++ b/apps/ios/Project.swift
@@ -54,7 +54,7 @@ let kelpieApp = Target.target(
             "OTHER_LDFLAGS": iOSLinkerFlags,
             "GENERATE_APP_INTENTS_METADATA": "NO",
             "APP_SHORTCUTS_ENABLE_FLEXIBLE_MATCHING": "NO",
-            "MARKETING_VERSION": "0.1.1",
+            "MARKETING_VERSION": "0.1.2",
             "TARGETED_DEVICE_FAMILY": "1,2",
             "DEVELOPMENT_TEAM": "G42HP8BM2N",
             // Conditional native build dir — device vs simulator

--- a/apps/macos/Kelpie/Info.plist
+++ b/apps/macos/Kelpie/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.11</string>
+	<string>0.1.12</string>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/apps/macos/Kelpie/Network/HTTPServer.swift
+++ b/apps/macos/Kelpie/Network/HTTPServer.swift
@@ -340,7 +340,7 @@ final class HTTPServer: @unchecked Sendable {
                 connection: connection,
                 response: PairingHTTPResponse.json(status: result.status, json: result.json, noStore: true)
             )
-        case ("GET", "/v1/get-device-info"):
+        case ("GET", "/v1/get-device-info"), ("POST", "/v1/get-device-info"):
             let result = pairEndpoints.handleGetDeviceInfo(
                 name: deviceInfo.name,
                 platform: deviceInfo.platform,

--- a/apps/macos/Kelpie/Network/PairEndpoints.swift
+++ b/apps/macos/Kelpie/Network/PairEndpoints.swift
@@ -72,7 +72,7 @@ struct PairEndpoints {
         return (200, ["success": removed])
     }
 
-    /// GET /v1/get-device-info (unauthenticated, public capability advert).
+    /// GET or POST /v1/get-device-info (unauthenticated, public capability advert).
     func handleGetDeviceInfo(name: String, platform: String, version: String) -> (status: Int, json: [String: Any]) {
         (200, [
             "name": name,

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -39,7 +39,7 @@ The HTTP server denies every `/v1/*` and `/mcp` call by default. The CLI must ob
 | `POST /v1/pair` | none + CSRF gate | `{clientId, clientName}` | `202 {status: "pending", requestId, expiresAt, sourceAddress}` |
 | `GET /v1/pair/status?requestId=…` | none | — | `200 {status: "pending"\|"approved"\|"denied"\|"expired"\|"not_found", scope?, token?}` |
 | `DELETE /v1/pair` | bearer | — | `200 {success: true}` — revokes the caller's own pairing |
-| `GET /v1/get-device-info` | none | — | `200 {name, platform, version, requiresPairing: true}` |
+| `GET or POST /v1/get-device-info` | none | — | `200 {name, platform, version, requiresPairing: true}` |
 
 The CSRF gate on `POST /v1/pair` requires `Content-Type: application/json`, an absent `Origin` header, single `Authorization` / `Content-Length` headers, and no `Transfer-Encoding`. Browsers cannot satisfy these constraints; the CLI's plain `fetch` does.
 

--- a/docs/plans/2026-05-16-pairing-auth.md
+++ b/docs/plans/2026-05-16-pairing-auth.md
@@ -38,7 +38,7 @@ Everything else — including `/mcp`, `/sse`, and every other `/v1/*` method —
 | `POST /v1/pair` | none + CSRF gate | `{clientId: uuid, clientName: string}` | `202 {status: "pending", requestId: nonce, expiresAt: ms, sourceAddress: ip}` |
 | `GET /v1/pair/status?requestId=X` | none | — | `200 {status: "pending"\|"approved"\|"denied"\|"expired"\|"not_found", scope?: "session"\|"persistent", token?: string}` — token returned **once** then pending entry deleted |
 | `DELETE /v1/pair` | bearer (revokes self only — clientId derived from token) | — | `200 {success: true}` |
-| `GET /v1/get-device-info` | none | — | `200 {name, platform, version, requiresPairing: true}` |
+| `GET or POST /v1/get-device-info` | none | — | `200 {name, platform, version, requiresPairing: true}` |
 | `/mcp`, `/sse`, all other `/v1/*` | **bearer required** | unchanged | `401 {error: {code: "UNAUTHORIZED"}}` |
 
 ### Token lifecycle

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlikeotherai/kelpie",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "Apache-2.0",
   "type": "module",
   "bin": {

--- a/packages/cli/src/discovery/local-probe.ts
+++ b/packages/cli/src/discovery/local-probe.ts
@@ -14,6 +14,9 @@ const LOCAL_PORT_SWEEP = 10;
 const platforms: readonly Platform[] = ["ios", "android", "macos", "linux", "windows"];
 
 interface DeviceInfoPayload {
+  name?: string;
+  platform?: string;
+  version?: string;
   device?: {
     id?: string;
     name?: string;
@@ -108,17 +111,17 @@ function localDevice(
   info: DeviceInfoPayload,
 ): DiscoveredDevice {
   const alias = aliasForPort(store, port);
-  const platform = parsePlatform(info.device?.platform, alias?.platform ?? "macos");
+  const platform = parsePlatform(info.device?.platform ?? info.platform, alias?.platform ?? "macos");
   return {
     id: `local:127.0.0.1:${port}`,
-    name: alias?.name ?? info.device?.name ?? `localhost:${port}`,
+    name: alias?.name ?? info.device?.name ?? info.name ?? `localhost:${port}`,
     ip: "127.0.0.1",
     port,
     platform,
     model: info.device?.model ?? `Kelpie ${platform}`,
     width: info.display?.width ?? 0,
     height: info.display?.height ?? 0,
-    version: info.app?.version ?? "0.0.0",
+    version: info.app?.version ?? info.version ?? "0.0.0",
     lastSeen: Date.now(),
   };
 }

--- a/packages/cli/tests/discovery/local-probe.test.ts
+++ b/packages/cli/tests/discovery/local-probe.test.ts
@@ -20,6 +20,15 @@ function deviceInfo(port: number): object {
   };
 }
 
+function publicDeviceInfo(): object {
+  return {
+    name: "dictator",
+    platform: "macos",
+    version: "0.1.11",
+    requiresPairing: true,
+  };
+}
+
 /** Stub fetch so only the given localhost ports answer as healthy Kelpie APIs. */
 function stubReachablePorts(ports: number[], infoPorts = ports): void {
   vi.stubGlobal(
@@ -83,6 +92,24 @@ describe("local-probe", () => {
       expect(await probeDeviceInfo(DEFAULT_PORT)).toEqual(deviceInfo(DEFAULT_PORT));
     });
 
+    it("accepts the public pairing-auth device info shape", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string | URL | Request) => {
+          const target = String(url);
+          if (target.includes(`:${DEFAULT_PORT}/v1/get-device-info`)) {
+            return new Response(JSON.stringify(publicDeviceInfo()), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          }
+          throw new Error("connection refused");
+        }),
+      );
+
+      expect(await probeDeviceInfo(DEFAULT_PORT)).toEqual(publicDeviceInfo());
+    });
+
     it("returns undefined when the automation endpoint does not respond", async () => {
       stubReachablePorts([DEFAULT_PORT], []);
       expect(await probeDeviceInfo(DEFAULT_PORT)).toBeUndefined();
@@ -103,6 +130,30 @@ describe("local-probe", () => {
       expect(device.version).toBe("0.1.8");
       expect(device.width).toBe(5120);
       expect(device.height).toBe(2880);
+    });
+
+    it("maps public pairing-auth device info into local fallback devices", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string | URL | Request) => {
+          const target = String(url);
+          if (target.includes(`:${DEFAULT_PORT}/health`)) {
+            return new Response("ok", { status: 200 });
+          }
+          if (target.includes(`:${DEFAULT_PORT}/v1/get-device-info`)) {
+            return new Response(JSON.stringify(publicDeviceInfo()), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          }
+          throw new Error("connection refused");
+        }),
+      );
+
+      const [device] = await probeLocalDevices();
+      expect(device.name).toBe("dictator");
+      expect(device.platform).toBe("macos");
+      expect(device.version).toBe("0.1.11");
     });
 
     it("skips unreachable ports", async () => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlikeotherai/kelpie-shared",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Accept `POST /v1/get-device-info` on iOS, macOS, and Android in addition to `GET`.
- Teach the CLI localhost fallback to read the public pairing-auth device info shape.
- Bump affected component versions for `release/2026-06-13.10`.

## Root Cause
The pairing-auth allowlist exposed unauthenticated `/v1/get-device-info` as a GET route, but CLI method transport sends `getDeviceInfo` as `POST /v1/get-device-info`. The native apps therefore returned 404 for the CLI unauthenticated local probe. The CLI also still mapped only the older nested device-info response, so it could not turn the public flat shape into a fallback localhost device.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm lint && pnpm build && pnpm test`
- `ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew build`
- `tuist generate`
- `make macos-build`
- `cmake -S native -B native/.build-iphoneos -G Xcode -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=16.0 -DKELPIE_BUILD_DESKTOP_ENGINES=OFF`
- `cmake --build native/.build-iphoneos --config Debug --target kelpie_core_protocol kelpie_core_state kelpie_core_automation kelpie_core_mcp kelpie_core_ai`
- `make ios-build IOS_TARGET=00008140-000651AE0139801C IOS_TYPE=device`
- `make ios-build IOS_TARGET=00008122-000E65163479801C IOS_TYPE=device`
- Installed `/tmp/gpteen-xcode2/Prod/Debug/Kelpie.app` to `/Applications/Kelpie.app` and verified POST `/v1/get-device-info` plus `kelpie info --timeout 10000`.